### PR TITLE
Prevent interface-type fields nodes emitting interface field usages for all implementing types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    byebug (10.0.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     diffy (3.2.1)
@@ -31,6 +32,9 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
     rake (10.5.0)
     redis (4.0.1)
     thread_safe (0.3.6)
@@ -51,6 +55,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   mocha
   pry
+  pry-byebug
   rake
 
 BUNDLED WITH

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "graphql", "~> 1.8.2"
   spec.add_development_dependency "activesupport", "~> 5.1.5"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "diffy"
   spec.add_development_dependency "fakeredis"

--- a/lib/graphql_metrics/extractor.rb
+++ b/lib/graphql_metrics/extractor.rb
@@ -250,7 +250,7 @@ module GraphQLMetrics
       extract_field(irep_node)
       extract_arguments(irep_node)
 
-      irep_node.typed_children.each_value do |children|
+      irep_node.scoped_children.each_value do |children|
         children.each_value do |child_irep_node|
           extract_node(child_irep_node)
         end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -13,6 +13,7 @@ class CommentLoader < GraphQL::Batch::Loader
 end
 
 class Comment < GraphQL::Schema::Object
+  implements GraphQL::Relay::Node.interface
   description "A blog comment"
 
   field :id, ID, null: false
@@ -20,6 +21,7 @@ class Comment < GraphQL::Schema::Object
 end
 
 class Post < GraphQL::Schema::Object
+  implements GraphQL::Relay::Node.interface
   description "A blog post"
 
   field :id, ID, null: false
@@ -64,6 +66,9 @@ class MutationRoot < GraphQL::Schema::Object
 end
 
 class QueryRoot < GraphQL::Schema::Object
+  field :node, field: GraphQL::Relay::Node.field
+  field :nodes, field: GraphQL::Relay::Node.plural_field
+
   field :post, Post, null: true do
     argument :id, ID, required: true
     argument :locale, String, required: false, default_value: 'en-us'


### PR DESCRIPTION
WIP. Only tests added at this point; implementation changes TBD.

# Problem

This PR introduces 2 failing tests, so that we can discuss and decide on a solution.

We discovered recently that this gem is duplicating metrics for field usages, across all Node-implementing types, for any query of the form:

```graphql
query MyQuery {
  node(id: "Comment-1") {
    id # We count n field usages, for all Node types
  }
}
```

or 

```graphql
query MyQuery {
  nodes(ids: ["Comment-1"]) {
    id # We count n field usages, for all Node types
  }
}
```

We (incorrectly?) get metrics for references to the `id` field on all Node-implementing types. Red = expected, green = actual.

```diff
{
   "fields": [
     {
       "type_name": "QueryRoot",
       "field_name": "node",
       "deprecated": false,
       "resolver_times": [
         0
       ]
     },
     {
-      "type_name": "Node",
+      "type_name": "Comment",
+      "field_name": "id",
+      "deprecated": false,
+      "resolver_times": [
+        0
+      ]
+    },
+    {
+      "type_name": "Post",
       "field_name": "id",
       "deprecated": false,
       "resolver_times": [
         0
       ]
     }
   ]
 }
```

Rather than a single `Node.id` field reference being counted, we count `Comment.id` and `Post.id`. If there were 100 more Node implementing types, we’d count all of them, too.

I guess this affects all fields that return an Interface. The common fields that are selected outside of a … on X { } are counted for all implementing types.

# Discussion

Does this seem wrong? For us to know whether a given type is being used by apps, it would be nice to know whether a type is not actually being used, but the type is simply implementing Node and being being counted because clients request `id` on Node.