### PR TITLE
Split out Instrumentation from Extractor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /spec/reports/
 /tmp/
 *.gem
+
+/vendor/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,8 @@ GEM
     metaclass (0.0.4)
     method_source (0.9.0)
     minitest (5.11.3)
+    minitest-focus (1.1.2)
+      minitest (>= 4, < 6)
     mocha (1.5.0)
       metaclass (~> 0.0.1)
     promise.rb (0.7.4)
@@ -53,6 +55,7 @@ DEPENDENCIES
   graphql-batch
   graphql-metrics!
   minitest (~> 5.0)
+  minitest-focus
   mocha
   pry
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ class LoggingExtractor < GraphQLMetrics::Extractor
       default_value_type: metrics[:default_value_type],   # "IMPLICIT_NULL"
       provided_value: metrics[:provided_value],           # false
       default_used: metrics[:default_used],               # false
+      used_in_query: metrics[:used_in_query],             # true
     })
   end
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ implementing the methods below, as needed.
 Here's an example of a simple extractor that logs out all GraphQL query details.
 
 ```ruby
-class LoggingExtractor < GraphQLMetrics::Extractor
+class LoggingExtractor < GraphQLMetrics::Instrumentation
   def query_extracted(metrics, _metadata)
     Rails.logger.debug({
       query_string: metrics[:query_string],     # "query Project { project(name: "GraphQL") { tagline } }"
@@ -103,7 +103,7 @@ class LoggingExtractor < GraphQLMetrics::Extractor
       default_value_type: metrics[:default_value_type],   # "IMPLICIT_NULL"
       provided_value: metrics[:provided_value],           # false
       default_used: metrics[:default_used],               # false
-      used_in_query: metrics[:used_in_query],             # true
+      used_in_operation: metrics[:used_in_operation],     # true
     })
   end
 
@@ -133,6 +133,32 @@ class LoggingExtractor < GraphQLMetrics::Extractor
   end
 end
 ```
+
+You can also define ad hoc query Extractors that can work with instances of GraphQL::Query, for example:
+
+```ruby
+class TypeUsageExtractor < GraphQLMetrics::Extractor
+  attr_reader :types_used
+
+  def initialize
+    @types_used = Set.new
+  end
+
+  def field_extracted(metrics, _metadata)
+    @types_used << metrics[:type_name]
+  end
+end
+
+# ...
+
+extractor = TypeUsageExtractor.new
+extractor.extract!(query)
+puts extractor.types_used
+# => ["Comment", "Post", "QueryRoot"]
+```
+
+Note that resolver-timing related data like `duration` in `query_extracted` and `resolver_times` in `field_extracted`
+won't be available when using an ad hoc Extractor, since the query isn't actually being run; it's only analyzed.
 
 ## Development
 

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -44,4 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "diffy"
   spec.add_development_dependency "fakeredis"
+  spec.add_development_dependency "minitest-focus"
 end

--- a/lib/graphql_metrics.rb
+++ b/lib/graphql_metrics.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require "graphql_metrics/version"
+require "graphql_metrics/instrumentation"
 require "graphql_metrics/extractor"
 require "graphql_metrics/timed_batch_executor"

--- a/lib/graphql_metrics/instrumentation.rb
+++ b/lib/graphql_metrics/instrumentation.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module GraphQLMetrics
+  class Instrumentation
+    extend Forwardable
+
+    CONTEXT_NAMESPACE = :extracted_metrics
+    TIMING_CACHE_KEY = :timing_cache
+    START_TIME_KEY = :query_start_time
+
+    attr_reader :ctx_namespace, :query
+    def_delegators :extractor, :extractor_defines_any_visitors?
+
+    def self.use(schema_definition)
+      instrumentation = self.new
+      return unless instrumentation.extractor_defines_any_visitors?
+
+      instrumentation.setup_instrumentation(schema_definition)
+    end
+
+    def self.current_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
+    def use(schema_definition)
+      return unless extractor_defines_any_visitors?
+      extractor.setup_instrumentation(schema_definition)
+    end
+
+    def setup_instrumentation(schema_definition)
+      schema_definition.instrument(:query, self)
+      schema_definition.instrument(:field, self)
+    end
+
+    def extractor
+      @extractor ||= Extractor.new(self)
+    end
+
+    def before_query(query)
+      return unless extractor_defines_any_visitors?
+
+      ns = query.context.namespace(CONTEXT_NAMESPACE)
+      ns[TIMING_CACHE_KEY] = {}
+      ns[START_TIME_KEY] = self.class.current_time
+    rescue StandardError => ex
+      extractor.handle_extraction_exception(ex)
+    end
+
+    def after_query(query)
+      @query = query
+
+      return unless extractor_defines_any_visitors?
+      return if respond_to?(:skip_extraction?) && skip_extraction?(query)
+      return unless @ctx_namespace = query.context.namespace(CONTEXT_NAMESPACE)
+
+      before_query_extracted(query, query.context) if respond_to?(:before_query_extracted)
+
+      extractor.extract!(query)
+
+      after_query_teardown(query) if respond_to?(:after_query_teardown)
+    rescue StandardError => ex
+      extractor.handle_extraction_exception(ex)
+    end
+
+    def instrument(type, field)
+      return field unless respond_to?(:field_extracted) || extractor.respond_to?(:field_extracted)
+      return field if type.introspection?
+
+      old_resolve_proc = field.resolve_proc
+      new_resolve_proc = ->(obj, args, ctx) do
+        start_time = self.class.current_time
+        result = old_resolve_proc.call(obj, args, ctx)
+
+        begin
+          next result if respond_to?(:skip_field_resolution_timing?) &&
+            skip_field_resolution_timing?(query, ctx)
+
+          end_time = self.class.current_time
+
+          ns = ctx.namespace(CONTEXT_NAMESPACE)
+
+          ns[TIMING_CACHE_KEY][ctx.ast_node] ||= []
+          ns[TIMING_CACHE_KEY][ctx.ast_node] << end_time - start_time
+
+          result
+        rescue StandardError => ex
+          extractor.handle_extraction_exception(ex)
+          result
+        end
+      end
+
+      field.redefine { resolve(new_resolve_proc) }
+    end
+  end
+end

--- a/lib/graphql_metrics/instrumentation.rb
+++ b/lib/graphql_metrics/instrumentation.rb
@@ -91,5 +91,16 @@ module GraphQLMetrics
 
       field.redefine { resolve(new_resolve_proc) }
     end
+
+    def after_query_resolver_times(ast_node)
+      ctx_namespace.dig(Instrumentation::TIMING_CACHE_KEY).fetch(ast_node, [])
+    end
+
+    def after_query_start_and_end_time
+      start_time = ctx_namespace[Instrumentation::START_TIME_KEY]
+      return unless start_time
+
+      [start_time, self.class.current_time]
+    end
   end
 end

--- a/lib/graphql_metrics/timed_batch_executor.rb
+++ b/lib/graphql_metrics/timed_batch_executor.rb
@@ -55,7 +55,7 @@ module GraphQLMetrics
 
     def resolve(loader)
       @resolve_meta = {
-        start_time: Process.clock_gettime(Process::CLOCK_MONOTONIC),
+        start_time: Instrumentation.current_time,
         current_loader: loader,
         perform_queue_sizes: loader.send(:queue).size
       }
@@ -66,7 +66,7 @@ module GraphQLMetrics
     def around_promise_callbacks
       return super unless @resolve_meta
 
-      end_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end_time = Instrumentation.current_time
 
       TIMINGS[@resolve_meta[:current_loader].loader_key] ||= { times: [], perform_queue_sizes: [] }
       TIMINGS[@resolve_meta[:current_loader].loader_key][:times] << end_time - @resolve_meta[:start_time]

--- a/test/redis_extractor.rb
+++ b/test/redis_extractor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module GraphQLMetrics
-  class RedisExtractor < GraphQLMetrics::Extractor
+  class RedisExtractor < GraphQLMetrics::Instrumentation
     def initialize
       @redis = Redis.new
     end
@@ -67,7 +67,7 @@ module GraphQLMetrics
           default_value_type: metrics[:default_value_type],
           provided_value: metrics[:provided_value],
           default_used: metrics[:default_used],
-          used_in_query: metrics[:used_in_query],
+          used_in_operation: metrics[:used_in_operation],
         }
       )
     end

--- a/test/redis_extractor.rb
+++ b/test/redis_extractor.rb
@@ -67,6 +67,7 @@ module GraphQLMetrics
           default_value_type: metrics[:default_value_type],
           provided_value: metrics[:provided_value],
           default_used: metrics[:default_used],
+          used_in_query: metrics[:used_in_query],
         }
       )
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'active_support'
 require 'graphql/batch'
 
 require "minitest/autorun"
+require "minitest/focus"
 require 'mocha/minitest'
 
 require 'pry'

--- a/test/unit/extractor_test.rb
+++ b/test/unit/extractor_test.rb
@@ -137,7 +137,7 @@ class ExtractorTest < ActiveSupport::TestCase
           default_value_type: "IMPLICIT_NULL",
           provided_value: false,
           default_used: false,
-          used_in_query: true
+          used_in_operation: true
         },
         {
           operation_name: "MyQuery",
@@ -146,7 +146,7 @@ class ExtractorTest < ActiveSupport::TestCase
           default_value_type: "NON_NULL",
           provided_value: false,
           default_used: true,
-          used_in_query: true
+          used_in_operation: true
         },
         {
           operation_name: "MyQuery",
@@ -155,7 +155,7 @@ class ExtractorTest < ActiveSupport::TestCase
           default_value_type: "EXPLICIT_NULL",
           provided_value: false,
           default_used: true,
-          used_in_query: true
+          used_in_operation: true
         },
         {
           operation_name: "OtherQuery",
@@ -164,7 +164,7 @@ class ExtractorTest < ActiveSupport::TestCase
           default_value_type: "IMPLICIT_NULL",
           provided_value: false,
           default_used: false,
-          used_in_query: false
+          used_in_operation: false
         }
       ],
       batch_loaded_fields: [
@@ -269,7 +269,7 @@ class ExtractorTest < ActiveSupport::TestCase
           default_value_type: "IMPLICIT_NULL",
           provided_value: false,
           default_used: false,
-          used_in_query: true
+          used_in_operation: true
         }
       ],
       batch_loaded_fields: []
@@ -279,7 +279,7 @@ class ExtractorTest < ActiveSupport::TestCase
   end
 
   test 'extractor with `before_query_extracted` callback' do
-    class ExtractorWithCallbacks < GraphQLMetrics::Extractor
+    class ExtractorWithCallbacks < GraphQLMetrics::Instrumentation
       attr_reader :from_context
 
       def before_query_extracted(_query, query_context)

--- a/test/unit/extractor_test.rb
+++ b/test/unit/extractor_test.rb
@@ -60,9 +60,24 @@ class ExtractorTest < ActiveSupport::TestCase
           }
         }
       }
+
+      query OtherQuery($unusedPostId: ID!) {
+        post(id: $unusedPostId) {
+          id
+        }
+      }
     QUERY
 
-    result_hash = Schema.execute(query_string, variables: { 'postId': '1', 'titleUpcase': true })
+    result_hash = Schema.execute(
+      query_string,
+      variables: {
+        'postId': '1',
+        'titleUpcase': true,
+        'unusedPostId': '1'
+      },
+      operation_name: 'MyQuery'
+    )
+
     assert_nil result_hash['errors']
     refute_nil result_hash['data']
 
@@ -121,7 +136,8 @@ class ExtractorTest < ActiveSupport::TestCase
           type: "ID!",
           default_value_type: "IMPLICIT_NULL",
           provided_value: false,
-          default_used: false
+          default_used: false,
+          used_in_query: true
         },
         {
           operation_name: "MyQuery",
@@ -129,7 +145,8 @@ class ExtractorTest < ActiveSupport::TestCase
           type: "Boolean",
           default_value_type: "NON_NULL",
           provided_value: false,
-          default_used: true
+          default_used: true,
+          used_in_query: true
         },
         {
           operation_name: "MyQuery",
@@ -137,7 +154,17 @@ class ExtractorTest < ActiveSupport::TestCase
           type: "[String!]",
           default_value_type: "EXPLICIT_NULL",
           provided_value: false,
-          default_used: true
+          default_used: true,
+          used_in_query: true
+        },
+        {
+          operation_name: "OtherQuery",
+          unwrapped_type_name: "ID",
+          type: "ID!",
+          default_value_type: "IMPLICIT_NULL",
+          provided_value: false,
+          default_used: false,
+          used_in_query: false
         }
       ],
       batch_loaded_fields: [
@@ -241,7 +268,8 @@ class ExtractorTest < ActiveSupport::TestCase
           type: "PostInput!",
           default_value_type: "IMPLICIT_NULL",
           provided_value: false,
-          default_used: false
+          default_used: false,
+          used_in_query: true
         }
       ],
       batch_loaded_fields: []

--- a/test/unit/non_instrumentation_extrator_test.rb
+++ b/test/unit/non_instrumentation_extrator_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "test_schema"
+
+class NonInstrumentationExtractorTest < ActiveSupport::TestCase
+  class TypeUsageExtractor < GraphQLMetrics::Extractor
+    attr_reader :types_used
+
+    def initialize
+      @types_used = Set.new
+    end
+
+    def field_extracted(metrics, _metadata)
+      @types_used << metrics[:type_name]
+    end
+
+    # Note: The below methods are implemented simply for test coverage (extractor code paths will be run, but their
+    # data won't be used.)
+
+    def query_extracted(_metrics, _metadata)
+      # No op
+    end
+
+    def batch_loaded_field_extracted(_metrics, _metadata)
+      # No op
+    end
+
+    def argument_extracted(_metrics, _metadata)
+      # No op
+    end
+
+    def variable_extracted(_metrics, _metadata)
+      # No op
+    end
+
+    def before_query_extracted(_query, query_context)
+      # No op
+    end
+
+    def skip_extraction?(_query)
+      # No op
+    end
+
+    def skip_field_resolution_timing?(_query, _metadata)
+      # No op
+    end
+
+    def after_query_teardown(_query)
+      # No op
+    end
+  end
+
+  class Schema < GraphQL::Schema
+    query QueryRoot
+    mutation MutationRoot
+
+    use GraphQL::Batch
+  end
+
+  test 'extracts metrics queries' do
+    query_string = <<~QUERY
+      query MyQuery($postId: ID!, $titleUpcase: Boolean = false, $commentsTags: [String!] = null) {
+        post(id: $postId) {
+          id
+          title(upcase: $titleUpcase)
+
+          ignoredAlias: body
+          deprecatedBody
+
+          comments(ids: [1, 2], tags: $commentsTags) {
+            id
+            body
+          }
+
+          otherComments: comments(ids: [3, 4]) {
+            id
+            body
+          }
+        }
+      }
+    QUERY
+
+    query = GraphQL::Query.new(
+      Schema,
+      query_string,
+      variables: { 'postId': '1', 'titleUpcase': true },
+    )
+
+    extractor = TypeUsageExtractor.new
+    extractor.extract!(query)
+
+    assert_equal %w(Comment Post QueryRoot), extractor.types_used.sort
+  end
+end


### PR DESCRIPTION
Introduces a new public method, `GraphQLMetrics::Extractor#extract!`, which takes in a `GraphQL::Query` and permits stateful extractors to be created that aren't used as instrumentation. See the test case below for an idea of its usage.

Only `field_extracted`, `initialize` and an `attr_reader` to pull out stored values is needed, but I implemented no-ops for the rest of the Extractor interface to ensure we detect breakage in those due to this or future changes.