### PR TITLE
Remove query_string from query_extracted

### DIFF
--- a/lib/graphql_metrics/extractor.rb
+++ b/lib/graphql_metrics/extractor.rb
@@ -97,7 +97,6 @@ module GraphQLMetrics
 
       query_extracted_method.call(
         {
-          query_string: query.document.to_query_string,
           operation_type: query.selected_operation.operation_type,
           operation_name: query.selected_operation_name,
           duration: duration

--- a/test/redis_instrumentation.rb
+++ b/test/redis_instrumentation.rb
@@ -10,7 +10,6 @@ module GraphQLMetrics
       @redis.lpush(
         'query_extracted',
         {
-          query_string: metrics[:query_string],
           operation_type: metrics[:operation_type],
           operation_name: metrics[:operation_name],
           duration: metrics[:duration],

--- a/test/unit/instrumentation_test.rb
+++ b/test/unit/instrumentation_test.rb
@@ -89,12 +89,9 @@ class InstrumentationTest < ActiveSupport::TestCase
       batch_loaded_fields: extract_from_redis('batch_loaded_field_extracted'),
     }
 
-    normalize_query_string_in_actual(actual)
-
     expected = {
       queries: [
         {
-          query_string: normalize_query_string(query_string),
           operation_type: "query",
           operation_name: "MyQuery",
           duration: 0
@@ -205,12 +202,9 @@ class InstrumentationTest < ActiveSupport::TestCase
       batch_loaded_fields: extract_from_redis('batch_loaded_field_extracted'),
     }
 
-    normalize_query_string_in_actual(actual)
-
     expected = {
       queries: [
         {
-          query_string: normalize_query_string(query_string),
           operation_type: "mutation",
           operation_name: "MyMutation",
           duration: 0
@@ -461,13 +455,5 @@ class InstrumentationTest < ActiveSupport::TestCase
 
   def extract_from_redis(key)
     @redis.lrange(key, 0, -1).map { |v| eval v }.reverse
-  end
-
-  def normalize_query_string_in_actual(actual)
-    actual[:queries].first[:query_string] = normalize_query_string(actual[:queries].first[:query_string])
-  end
-
-  def normalize_query_string(query_string)
-    query_string.gsub(/\n/, ' ').squish
   end
 end


### PR DESCRIPTION
This was calling `to_query_string` regardless of its used or not which could have some performance costs.

The `query` itself is passed into the `metadata` already so if the query string is needed it can be gotten from there.