### PR TITLE
Do not hold onto a useless graph query

### DIFF
--- a/lib/graphql_metrics/instrumentation.rb
+++ b/lib/graphql_metrics/instrumentation.rb
@@ -61,6 +61,8 @@ module GraphQLMetrics
       after_query_teardown(query) if respond_to?(:after_query_teardown)
     rescue StandardError => ex
       extractor.handle_extraction_exception(ex)
+    ensure
+      @query = nil
     end
 
     def instrument(type, field)


### PR DESCRIPTION
Similar to: https://github.com/Shopify/shopify/pull/195058
And: https://github.com/Shopify/shopify/pull/195079

Edit: since that a public repo I should explain.

Some heap inspection showed that `GraphApi::MetricsLogger` was holding onto a `GraphQL::Query` instance. This isn't great because it mean we'll always keep one Query and it's result in memory, and it won't be able to be reclaimed until it's replaced by another one.

```
harb> rootpath 0x55c01ff587c0

root path to 0x55c01ff587c0:
                      ROOT (machine_context)
                      0x55bfcfbf0560 (CLASS: RubyVM::InstructionSequence)
                      0x55bfcfc21728 (CLASS: Object)
                      0x55bfd24d5a98 (MODULE: GraphApi)
                      0x55bfe0505d98 (MODULE: GraphApi::Storefront)
                      0x55bfebba61b0 (OBJECT: GraphModel::Schema)
                      0x55bfebba62a0 (ARRAY: size 1)
                      0x55bfebba62c8 (OBJECT: GraphApi::MetricsLogger)
                      0x55c01fe321c0 (OBJECT: GraphQL::Query)
                      0x55c01fd095a0 (OBJECT: GraphApi::Storefront::MutationRoot)
                      0x55c01fef7c40 (OBJECT: [REDACTED])
                      0x55c01ff5dc20 (ARRAY: size 226)
                      0x55c01ff58900 (HASH: size 2)
                      0x55c01ff587c0 (STRING: "[REDACTED]")
```
