### PR TITLE
Handle logging for empty input objects with no required fields

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -104,7 +104,7 @@ module GraphQL
           extract_arguments(argument.value, field_defn, parent_input_object)
         when ::GraphQL::Schema::InputObject
           input_object_argument_values = argument.arguments.argument_values.values
-          parent_input_object = input_object_argument_values.first.definition.metadata[:type_class].owner
+          parent_input_object = input_object_argument_values.first&.definition&.metadata[:type_class]&.owner
 
           extract_arguments(input_object_argument_values, field_defn, parent_input_object)
         end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -68,6 +68,11 @@ class PostInput < GraphQL::Schema::InputObject
   argument :embedded_tags, [TagInput], "Embedded tags on a post", required: true
 end
 
+class PostUpdateInput < GraphQL::Schema::InputObject
+  argument :title, String, "Title for the post", required: false, default_value: ""
+  argument :body, String, "Body of the post", required: false
+end
+
 class PostCreate < GraphQL::Schema::Mutation
   argument :post, PostInput, required: true
 
@@ -79,8 +84,19 @@ class PostCreate < GraphQL::Schema::Mutation
   end
 end
 
+class PostUpdate < GraphQL::Schema::Mutation
+  argument :post, PostUpdateInput, required: true
+
+  field :success, Boolean, null: false
+
+  def resolve(post:)
+    { success: true }
+  end
+end
+
 class MutationRoot < GraphQL::Schema::Object
   field :post_create, mutation: PostCreate
+  field :post_update, mutation: PostUpdate
 end
 
 class QueryRoot < GraphQL::Schema::Object


### PR DESCRIPTION
Follow-up to https://github.com/Shopify/shopify/issues/228877

## What

Fixes bug encountered when PR https://github.com/Shopify/shopify/pull/229120 was rolled out , caused by arguments of `{}` passed as input object types which require no fields (even if they provide a default value).

## How?

Added safe navigation around input object arguments, to ensure we don't assume there always are argument values provided by the app (i.e. when `{}` is provided).

Note that input object fields that do provide a default (like `PostUpdateInput#title` in the toy schema in this gem's test suite) have metrics extracted with the appropriate `parent_input_object_type` value, even if applications (like ours) don't log them.

Note also that `PostUpdateInput#body` isn't included in the metrics since it wasn't provided and has no default.