### PR TITLE
Handle logging for empty input objects with no required fields

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -104,7 +104,7 @@ module GraphQL
           extract_arguments(argument.value, field_defn, parent_input_object)
         when ::GraphQL::Schema::InputObject
           input_object_argument_values = argument.arguments.argument_values.values
-          parent_input_object = input_object_argument_values.first&.definition&.metadata[:type_class]&.owner
+          parent_input_object = input_object_argument_values.first&.definition&.metadata&.fetch(:type_class, nil)&.owner
 
           extract_arguments(input_object_argument_values, field_defn, parent_input_object)
         end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -73,6 +73,10 @@ class PostUpdateInput < GraphQL::Schema::InputObject
   argument :body, String, "Body of the post", required: false
 end
 
+class PostUpvoteInput < GraphQL::Schema::InputObject
+  argument :upvote_value, Integer, "Upvote 1 or -1", required: false
+end
+
 class PostCreate < GraphQL::Schema::Mutation
   argument :post, PostInput, required: true
 
@@ -94,9 +98,20 @@ class PostUpdate < GraphQL::Schema::Mutation
   end
 end
 
+class PostUpvote < GraphQL::Schema::Mutation
+  argument :upvote, PostUpvoteInput, required: true
+
+  field :success, Boolean, null: false
+
+  def resolve(upvote:)
+    { success: true }
+  end
+end
+
 class MutationRoot < GraphQL::Schema::Object
   field :post_create, mutation: PostCreate
   field :post_update, mutation: PostUpdate
+  field :post_upvote, mutation: PostUpvote
 end
 
 class QueryRoot < GraphQL::Schema::Object

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -772,7 +772,7 @@ module GraphQL
         assert_equal_with_diff_on_failure(expected_arguments, actual_arguments)
       end
 
-      test 'handles input objects with no required fields (one of which has a default) are passed in as `{}`' do
+      test 'handles input objects with no required fields (ONE of which has a default) are passed in as `{}`' do
         query_document = <<~GRAPHQL
           mutation PostUpdate {
             postUpdate(post: {}) {
@@ -808,6 +808,40 @@ module GraphQL
             :parent_input_object_type=> "PostUpdateInput",
             :default_used=> true,
             :value_is_null=> false,
+            :value => SomeArgumentValue.new,
+          }
+        ]
+
+        assert_equal_with_diff_on_failure(expected_arguments, actual_arguments)
+      end
+
+      test 'handles input objects with no required fields (NONE of which have a default) are passed in as `{}`' do
+        query_document = <<~GRAPHQL
+          mutation PostUpvote {
+            postUpvote(upvote: {}) {
+              success
+            }
+          }
+        GRAPHQL
+
+        query = GraphQL::Query.new(SchemaWithFullMetrics, query_document)
+        result = query.result.to_h
+
+        refute result['errors'].present?
+        assert result['data'].present?
+
+        metrics_results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        actual_arguments = metrics_results[:arguments]
+
+        expected_arguments = [
+          {
+            :argument_name=>"upvote",
+            :argument_type_name=>"PostUpvoteInput",
+            :parent_field_name=>"postUpvote",
+            :parent_field_type_name=>"MutationRoot",
+            :parent_input_object_type=>nil,
+            :default_used=>false,
+            :value_is_null=>false,
             :value => SomeArgumentValue.new,
           }
         ]


### PR DESCRIPTION
Fixes incorrect safe navigation (using `fetch` for `Hash#[]` lookup) for scenario that I initially reproduced, but then accidentally dropped test coverage for in https://github.com/Shopify/graphql-metrics/pull/14.

In short, I initially reproduced and fixed this bug in the previous PR, but then before pushing it up for review, decided to make one of the non-required input fields on the type under test have a default: https://github.com/Shopify/graphql-metrics/compare/handle-empty-input-objects-with-no-required-fields-v2?expand=1#diff-c42c2b878c3bbd8304620e9949ebdaebR72

This ended up with me no longer testing the scenario where `input_object_argument_values.first` is nil (since defaults get populated into `input_object_argument_values`), and after refactoring an `if` conditional that did a nil check into a single line safe navigation approach, I hadn't noticed I'd broken the code in the process.

This PR fixes this, and adds another test for a mutation that takes an input type that both has no required fields as well as no defaults: this truly reproduces the error seen in production (https://github.com/Shopify/shopify/pull/229674), and fixes and tests it properly.