### PR TITLE
WIP Fix graphql-ruby supported version range

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphql-metrics (3.0.0)
       concurrent-ruby (~> 1.1.0)
-      graphql (~> 1.9.15)
+      graphql (> 1.9.5, < 2)
 
 GEM
   remote: https://rubygems.org/
@@ -19,8 +19,8 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    graphql (1.9.16)
-    graphql-batch (0.4.1)
+    graphql (1.10.4)
+    graphql-batch (0.4.2)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     hashdiff (1.0.0)
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.1.5)
-  bundler (~> 2.0.2)
+  bundler (~> 2.1.4)
   diffy
   fakeredis
   graphql-batch
@@ -65,4 +65,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
-  spec.add_runtime_dependency "graphql", "~> 1.9.15"
+  spec.add_runtime_dependency "graphql", "> 1.9.5", "< 2"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'graphql-batch'


### PR DESCRIPTION
Closes https://github.com/Shopify/graphql-metrics/issues/16

Sets the range of compatible graphql-ruby versions to ` "> 1.9.5", "< 2"`.

Metrics 3.0.0 appears is currently compatible with graphql-ruby versions 1.9.5 up to and excluding 1.10.0. Need a fix here to ensure the gem works with 1.10.x.

Currently failing on versions > 1.10.0 on this line: https://github.com/Shopify/graphql-metrics/blob/82889616cd35fb3e2d139261ddb9090107ab27b7/lib/graphql/metrics/analyzer.rb#L35

Getting method not found when calling `.introspection?`