### PR TITLE
WIP - Need alternate source of argument/parent field definition data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphql-metrics (3.0.0)
       concurrent-ruby (~> 1.1.0)
-      graphql (~> 1.9.15)
+      graphql (> 1.9.5, < 2)
 
 GEM
   remote: https://rubygems.org/
@@ -19,8 +19,8 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    graphql (1.9.16)
-    graphql-batch (0.4.1)
+    graphql (1.10.4)
+    graphql-batch (0.4.2)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     hashdiff (1.0.0)
@@ -51,7 +51,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.1.5)
-  bundler (~> 2.0.2)
+  bundler (~> 2.1.4)
   diffy
   fakeredis
   graphql-batch
@@ -65,4 +65,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphql-metrics (3.0.0)
       concurrent-ruby (~> 1.1.0)
-      graphql (> 1.9.5, < 2)
+      graphql (= 1.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,7 +19,7 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    graphql (1.10.4)
+    graphql (1.10.0)
     graphql-batch (0.4.2)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -31,7 +31,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
-  spec.add_runtime_dependency "graphql", "> 1.9.5", "< 2"
+  # spec.add_runtime_dependency "graphql", "> 1.9.5", "< 2"
+  spec.add_runtime_dependency "graphql", "1.10.0"
+  # spec.add_runtime_dependency "graphql", "1.9.5"
 
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
-  spec.add_runtime_dependency "graphql", "~> 1.9.15"
+  spec.add_runtime_dependency "graphql", "> 1.9.5", "< 2"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'graphql-batch'

--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -48,6 +48,21 @@ module GraphQL
       TimedResult.new(*args) { yield }
     end
 
+    class GraphQLGemVersion
+      def initialize(version_string)
+        # TODO use Gem::Version.new('0.10.1') instead?
+        @version_string = version_string.split('.').map(&:to_i)
+      end
+
+      def is_1_9?
+        @version_string[0] == 1 && @version_string[1] == 9
+      end
+
+      def is_1_10?
+        @version_string[0] == 1 && @version_string[1] == 10
+      end
+    end
+
     class TimedResult
       # NOTE: `time_since_offset` is used to produce start times timed phases of execution (validation, field
       # resolution). These start times are relative to the executed operation's start time, which is captured at the

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -90,6 +90,7 @@ module GraphQL
         end
       end
 
+      focus
       test 'extracts metrics from queries, as well as their fields and arguments' do
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,


### PR DESCRIPTION
In https://github.com/Shopify/graphql-metrics/pull/17 I encountered the first breaking changes in graphql-ruby 1.10.x.

In this PR, I'm exploring whether graphql-metrics 3.0.x can / should introduce versioned logic to remain compatible with graphql-ruby 1.9.5+ as well as 1.10.x.

So far, it looks like the only breaking changes to consider are:
* Needing to use `visitor.field_definition.type.unwrap.introspection?` to see if a field is an introspection field (**already fixed in this PR**)
* `visitor.arguments_for` returning a hash of symbol keys -> actual scalar argument values, rather than an array of the kind of objects we handle in the current `extract_arguments` recursive method, (**i.e. what this PR aims to explore**): https://github.com/Shopify/graphql-metrics/blob/82889616cd35fb3e2d139261ddb9090107ab27b7/lib/graphql/metrics/analyzer.rb#L88-L111