### PR TITLE
Fix graphql-ruby 1.9.x support range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+3.0.1
+-----
+
+Expand the range of graphql-ruby versions this gem is compatible with.
+
 3.0.0
 -----
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    graphql-metrics (3.0.0)
+    graphql-metrics (3.0.1)
       concurrent-ruby (~> 1.1.0)
-      graphql (~> 1.9.15)
+      graphql (>= 1.9.5, < 1.10.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,7 +19,7 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    graphql (1.9.16)
+    graphql (1.9.19)
     graphql-batch (0.4.1)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
@@ -51,7 +51,6 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 5.1.5)
-  bundler (~> 2.0.2)
   diffy
   fakeredis
   graphql-batch
@@ -65,4 +64,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -31,9 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
-  spec.add_runtime_dependency "graphql", "~> 1.9.15"
+  spec.add_runtime_dependency "graphql", ">= 1.9.5", "< 1.10.0"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'graphql-batch'

--- a/lib/graphql/metrics/version.rb
+++ b/lib/graphql/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Metrics
-    VERSION = "3.0.0"
+    VERSION = "3.0.1"
   end
 end


### PR DESCRIPTION
Metrics 3.0.0 works with graphql-ruby 1.9.5 to 1.9.19. Until we work out how 1.10.x breaking changes should be handled in the gem (as either graphql-ruby version checks, or a new 4.0.0 release of graphql-metrics), we may as well support most of the 1.9.x range.