### PR TITLE
graphql-ruby 1.10.8+ compatibility

### DIFF
--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -76,13 +76,6 @@ Style/BlockDelimiters:
   - proc
   - it
 
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
-
 Layout/CaseIndentation:
   EnforcedStyle: end
   SupportedStyles:
@@ -509,7 +502,7 @@ Style/WhileUntilModifier:
 Metrics/BlockNesting:
   Max: 3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,6 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in graphql_metrics.gemspec
-
-gem 'graphql', github: 'rmosolgo/graphql-ruby', branch: 'query-args-default-values' # TODO remove once fix is in 1.10
-
 gemspec
 
 group :deployment do

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,9 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in graphql_metrics.gemspec
+
+gem 'graphql', github: 'rmosolgo/graphql-ruby', branch: 'query-args-default-values' # TODO remove once fix is in 1.10
+
 gemspec
 
 group :deployment do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,9 @@
-GIT
-  remote: https://github.com/rmosolgo/graphql-ruby
-  revision: a5f2744307710dc560ac8e59cba1520a215aa52f
-  branch: query-args-default-values
-  specs:
-    graphql (1.10.6)
-
 PATH
   remote: .
   specs:
     graphql-metrics (4.0.0)
       concurrent-ruby (~> 1.1.0)
-      graphql (>= 1.10.6, < 1.11.0)
+      graphql (>= 1.10.8)
 
 GEM
   remote: https://rubygems.org/
@@ -26,6 +19,7 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
+    graphql (1.10.8)
     graphql-batch (0.4.2)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
@@ -59,7 +53,6 @@ DEPENDENCIES
   activesupport (~> 5.1.5)
   diffy
   fakeredis
-  graphql!
   graphql-batch
   graphql-metrics!
   hashdiff

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,16 @@
+GIT
+  remote: https://github.com/rmosolgo/graphql-ruby
+  revision: a5f2744307710dc560ac8e59cba1520a215aa52f
+  branch: query-args-default-values
+  specs:
+    graphql (1.10.6)
+
 PATH
   remote: .
   specs:
-    graphql-metrics (3.0.2)
+    graphql-metrics (4.0.0)
       concurrent-ruby (~> 1.1.0)
-      graphql (>= 1.9.5, < 1.10.0)
+      graphql (>= 1.10.6, < 1.11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -19,8 +26,7 @@ GEM
     diffy (3.3.0)
     fakeredis (0.7.0)
       redis (>= 3.2, < 5.0)
-    graphql (1.9.19)
-    graphql-batch (0.4.1)
+    graphql-batch (0.4.2)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     hashdiff (1.0.0)
@@ -53,6 +59,7 @@ DEPENDENCIES
   activesupport (~> 5.1.5)
   diffy
   fakeredis
+  graphql!
   graphql-batch
   graphql-metrics!
   hashdiff

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -30,9 +30,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
-  spec.add_runtime_dependency "graphql", ">= 1.9.5", "< 1.10.0"
+  # TODO update first constraint to ">= 1.10.8" once https://github.com/rmosolgo/graphql-ruby/pull/2881 ships
+  spec.add_runtime_dependency "graphql", ">= 1.10.6", "< 1.11.0"
 
+  spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency 'graphql-batch'

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -30,9 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # TODO update first constraint to ">= 1.10.8" once https://github.com/rmosolgo/graphql-ruby/pull/2881 ships
-  spec.add_runtime_dependency "graphql", ">= 1.10.6", "< 1.11.0"
-
+  spec.add_runtime_dependency "graphql", ">= 1.10.8"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.1.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -32,17 +32,17 @@ module GraphQL
       end
 
       def on_leave_field(node, _parent, visitor)
-        return if visitor.field_definition.introspection?
+        return if visitor.field_definition.graphql_definition.introspection?
         return if query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
 
-        # NOTE: @rmosolgo "I think it could be reduced to `arguments = visitor.arguments_for(ast_node)`"
-        arguments = visitor.arguments_for(node, visitor.field_definition)
-        extract_arguments(arguments.argument_values.values, visitor.field_definition)
+        argument_values = query.arguments_for(node, visitor.field_definition, detailed: true)
+
+        extract_arguments(argument_values, visitor.field_definition)
 
         static_metrics = {
           field_name: node.name,
-          return_type_name: visitor.type_definition.name,
-          parent_type_name: visitor.parent_type_definition.name,
+          return_type_name: visitor.type_definition.graphql_name,
+          parent_type_name: visitor.parent_type_definition.graphql_name,
           deprecated: visitor.field_definition.deprecation_reason.present?,
           path: visitor.response_path,
         }
@@ -93,16 +93,16 @@ module GraphQL
           argument.each_value do |a|
             extract_arguments(a, field_defn, parent_input_object)
           end
-        when ::GraphQL::Query::Arguments
+        when ::GraphQL::Execution::Interpreter::Arguments
           argument.each_value do |arg_val|
             extract_arguments(arg_val, field_defn, parent_input_object)
           end
-        when ::GraphQL::Query::Arguments::ArgumentValue
+        when ::GraphQL::Execution::Interpreter::Arguments::ArgumentValue
           extract_argument(argument, field_defn, parent_input_object)
           extract_arguments(argument.value, field_defn, parent_input_object)
         when ::GraphQL::Schema::InputObject
           input_object_argument_values = argument.arguments.argument_values.values
-          parent_input_object = input_object_argument_values.first&.definition&.metadata&.fetch(:type_class, nil)&.owner
+          parent_input_object = input_object_argument_values.first&.definition&.owner
 
           extract_arguments(input_object_argument_values, field_defn, parent_input_object)
         end
@@ -110,10 +110,10 @@ module GraphQL
 
       def extract_argument(value, field_defn, parent_input_object = nil)
         static_metrics = {
-          argument_name: value.definition.expose_as,
-          argument_type_name: value.definition.type.unwrap.to_s,
-          parent_field_name: field_defn.name,
-          parent_field_type_name: field_defn.metadata[:type_class].owner.graphql_name,
+          argument_name: value.definition.graphql_name,
+          argument_type_name: value.definition.type.unwrap.graphql_name,
+          parent_field_name: field_defn.graphql_name,
+          parent_field_type_name: field_defn.owner.graphql_name,
           parent_input_object_type: parent_input_object&.graphql_name,
           default_used: value.default_used?,
           value_is_null: value.value.nil?,

--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -32,10 +32,10 @@ module GraphQL
       end
 
       def on_leave_field(node, _parent, visitor)
-        return if visitor.field_definition.graphql_definition.introspection?
+        return if visitor.field_definition.introspection?
         return if query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
 
-        argument_values = query.arguments_for(node, visitor.field_definition, detailed: true)
+        argument_values = query.arguments_for(node, visitor.field_definition)
 
         extract_arguments(argument_values, visitor.field_definition)
 
@@ -97,7 +97,7 @@ module GraphQL
           argument.each_value do |arg_val|
             extract_arguments(arg_val, field_defn, parent_input_object)
           end
-        when ::GraphQL::Execution::Interpreter::Arguments::ArgumentValue
+        when ::GraphQL::Execution::Interpreter::ArgumentValue
           extract_argument(argument, field_defn, parent_input_object)
           extract_arguments(argument.value, field_defn, parent_input_object)
         when ::GraphQL::Schema::InputObject

--- a/lib/graphql/metrics/version.rb
+++ b/lib/graphql/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Metrics
-    VERSION = "3.0.3"
+    VERSION = "4.0.0"
   end
 end

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -29,7 +29,7 @@ module GraphQL
         include Comparable
 
         def <=>(other)
-          other.is_a?(GraphQL::Execution::Interpreter::Arguments::ArgumentValue) ? 0 : nil
+          other.is_a?(GraphQL::Execution::Interpreter::ArgumentValue) ? 0 : nil
         end
 
         def to_s

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -29,7 +29,7 @@ module GraphQL
         include Comparable
 
         def <=>(other)
-          other.is_a?(GraphQL::Query::Arguments::ArgumentValue) ? 0 : nil
+          other.is_a?(GraphQL::Execution::Interpreter::Arguments::ArgumentValue) ? 0 : nil
         end
 
         def to_s


### PR DESCRIPTION
Blocked by https://github.com/rmosolgo/graphql-ruby/pull/2881 and the release of graphql-ruby v1.10.8 or later which would include #2881.

Background on the upstream regression/blocker: https://github.com/rmosolgo/graphql-ruby/issues/2841

The core change of this PR is this line:
```ruby
argument_values = query.arguments_for(node, visitor.field_definition, detailed: true)
```

... in which we make use of the new `detailed:` kwarg, which when used provides the argument metadata needed by graphql-metrics.