### PR TITLE
Safely call arguments_for

### DIFF
--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -38,7 +38,13 @@ class Post < GraphQL::Schema::Object
   field :id, ID, null: false
 
   field :title, String, null: false do
-    argument :upcase, Boolean, required: false
+    argument :upcase, Boolean, required: false, prepare: ->(value, ctx) do
+      if ctx[:raise_in_prepare]
+        raise GraphQL::ExecutionError, "error in prepare"
+      else
+        value
+      end
+    end
   end
 
   field :body, String, null: false do


### PR DESCRIPTION
We need to add our own error handling to catch `ExecutionError`s which
may be raised within an argument's `prepare` method since the gem does
not.