### PR TITLE
Safely handle interrupted runtime metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ etc.
 
 What you do with these captured metrics is up to you!
 
+**NOTE**: Runtime metrics on for queries (like `query_duration`, `parsing_start_time_offset` etc.) as well as field
+resolver timings (like `resolver_timings`, `lazy_resolver_timings`) may not be present in the extracted `metrics` hash,
+even if you opt to collect them by using `GraphQL::Metrics::Analyzer` and `GraphQL::Metrics::Tracer`.
+
+More specifically, if any non-`graphql-ruby` gem-related exceptions occur in your application during query document
+parsing and validation runtime metrics will not be added to the `metrics` hash.
+
 ### Define your own analyzer subclass
 
 ```ruby
@@ -173,7 +180,7 @@ class Schema < GraphQL::Schema
   use GraphQL::Analysis::AST # Required.
 
   query_analyzer SimpleAnalyzer
-  
+
   instrument :query, GraphQL::Metrics::Instrumentation.new # Both of these are required if either is used.
   tracer GraphQL::Metrics::Tracer.new                      # <-- Note!
 

--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -61,17 +61,20 @@ module GraphQL
         end
       end
 
-      def extract_fields_with_runtime_metrics
+      def extract_fields(with_runtime_metrics: true)
         return if query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
 
         ns = query.context.namespace(CONTEXT_NAMESPACE)
 
         @static_field_metrics.each do |static_metrics|
-          resolver_timings = ns[GraphQL::Metrics::INLINE_FIELD_TIMINGS][static_metrics[:path]]
-          lazy_resolver_timings = ns[GraphQL::Metrics::LAZY_FIELD_TIMINGS][static_metrics[:path]]
 
-          static_metrics[:resolver_timings] = resolver_timings || []
-          static_metrics[:lazy_resolver_timings] = lazy_resolver_timings || []
+          if with_runtime_metrics
+            resolver_timings = ns[GraphQL::Metrics::INLINE_FIELD_TIMINGS][static_metrics[:path]]
+            lazy_resolver_timings = ns[GraphQL::Metrics::LAZY_FIELD_TIMINGS][static_metrics[:path]]
+
+            static_metrics[:resolver_timings] = resolver_timings || []
+            static_metrics[:lazy_resolver_timings] = lazy_resolver_timings || []
+          end
 
           field_extracted(static_metrics)
         end

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -29,7 +29,7 @@ module GraphQL
 
         if runtime_metrics_interrupted?(ns)
           # If runtime metrics were interrupted, then it's most likely that the application raised an exception and that
-          # query parsing (which is instrumenetd by GraphQL::Metrics::Tracer) was abruptly stopped.
+          # query parsing (which is instrumented by GraphQL::Metrics::Tracer) was abruptly stopped.
           #
           # In this scenario, we still attempt to log whatever static query metrics we've collected, with runtime
           # metrics (like query, field resolver timings) excluded.
@@ -63,7 +63,7 @@ module GraphQL
       def runtime_metrics_interrupted?(context_namespace)
         # NOTE: The start time stored at `ns[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC]` is captured during query
         # parsing, which occurs before `Instrumentation#before_query`.
-        context_namespace[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC].nil?
+        context_namespace.key?(GraphQL::Metrics::QUERY_START_TIME_MONOTONIC) == false
       end
     end
   end


### PR DESCRIPTION
# The problem

Related to / re-surfaced by https://github.com/Shopify/shopify/issues/250502

Once in a while, we've noticed graphql-metrics obscuring unrelated exceptions. These exceptions happen (as far as I can tell) incidentally while GraphQL queries are being parsed and validated, and importantly: these exceptions can happen before graphql-metrics is able to put a few time-related values into the query's context.

If non-graphly-ruby related exceptions are raised at this time, graphql-metrics currently obscures this errors by attempting to subtract the current time (which is always available) from a context stored value which may not have been set.

```ruby
GraphQL::Metrics.current_time_monotonic -
  ns[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC] # can be null due to application exceptions
```

# A proposed solution

I've added some logic to `Instrumentation` to check for whether this scenario has happened, and accordingly updated `Analyzer` to be able to run in a degraded failure mode, by still attempting to log static query/field/arg metrics.

This will require an update to the README to explain these runtime metrics' nullability, and we'll have to decide in Shopify whether we should omit or log with default values (empty arrays?) of runtime values like query/field timings.

Another option might be to safely return an empty array of timings, but I think the metrics hashes missing these values would be a less ambiguous signal to application developers.