### PR TITLE
Fix sample analyzer name in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ parsing and validation runtime metrics will not be added to the `metrics` hash.
 ### Define your own analyzer subclass
 
 ```ruby
-  class CaptureAllMetricsAnalyzer < GraphQL::Metrics::Analyzer
-    ANALYZER_NAMESPACE = :capture_all_metrics_analyzer_namespace
+  class SimpleAnalyzer < GraphQL::Metrics::Analyzer
+    ANALYZER_NAMESPACE = :simple_analyzer_namespace
 
     def initialize(query_or_multiplex)
       super


### PR DESCRIPTION
The README uses both `SimpleAnalyzer` and `CaptureAllMetricsAnalyzer` in usage snippets which means the examples don't work via copy/paste. This PR standardizes on `SimpleAnalyzer` but I don't have strong opinions on which name is better.