### PR TITLE
Remove runtime dependency on activesupport

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -50,7 +50,7 @@ module GraphQL
           field_name: node.name,
           return_type_name: visitor.type_definition.graphql_name,
           parent_type_name: visitor.parent_type_definition.graphql_name,
-          deprecated: visitor.field_definition.deprecation_reason.present?,
+          deprecated: !visitor.field_definition.deprecation_reason.nil?,
           path: visitor.response_path,
         }
 


### PR DESCRIPTION
This PR removes the undeclared runtime dependency on the `present?` method from Active Support. It changes the semantics of a field's `deprecated` attribute slightly to now consider fields with non-null, blank deprecation reasons as deprecated. This matches the behavior of graphql-ruby [introspection](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/introspection/field_type.rb#L16) so it's probably a good change anyway.

Unfortunately Active Support is loaded when running tests so it's pretty hard to ensure this won't break in the future. In [theory](https://guides.rubyonrails.org/active_support_core_extensions.html#how-to-load-core-extensions) Active Support core extensions shouldn't be loaded by default via a `require 'active_support'` but in reality there's a dependency chain from `ActiveSupport::TestCase` to `ActiveSupport::XmlMini_REXML` to `active_support/core_ext/object/blank`. Longer term it might be worth removing the Active Support test dependency to ensure this doesn't break.

Fixes #28.