### PR TITLE
Handle queries that have already been parsed

### DIFF
--- a/lib/graphql/metrics/tracer.rb
+++ b/lib/graphql/metrics/tracer.rb
@@ -4,7 +4,7 @@ module GraphQL
   module Metrics
     class Tracer
       # NOTE: These constants come from the graphql ruby gem.
-      GRAPHQL_GEM_LEXING_KEY = 'lex'
+      GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY = 'execute_multiplex'
       GRAPHQL_GEM_PARSING_KEY = 'parse'
       GRAPHQL_GEM_VALIDATION_KEYS = ['validate', 'analyze_query']
       GRAPHQL_GEM_TRACING_FIELD_KEYS = [
@@ -20,10 +20,10 @@ module GraphQL
         return yield if skip_tracing
 
         # NOTE: Not all tracing events are handled here, but those that are are handled in this case statement in
-        # chronological order.
+        # chronological order. Lexing and parsing will be skipped when executing an already parsed query document.
         case key
-        when GRAPHQL_GEM_LEXING_KEY
-          return setup_tracing_before_lexing(&block)
+        when GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY
+          return setup_tracing(&block)
         when GRAPHQL_GEM_PARSING_KEY
           return capture_parsing_time(&block)
         when *GRAPHQL_GEM_VALIDATION_KEYS
@@ -34,8 +34,6 @@ module GraphQL
         when *GRAPHQL_GEM_TRACING_FIELD_KEYS
           return yield if data[:query].context[SKIP_FIELD_AND_ARGUMENT_METRICS]
           return yield unless GraphQL::Metrics.timings_capture_enabled?(data[:query].context)
-
-          pre_context = nil
 
           context_key = case key
           when GRAPHQL_GEM_TRACING_FIELD_KEY
@@ -52,15 +50,25 @@ module GraphQL
 
       private
 
+      PreContext = Struct.new(:query_start_time, :query_start_time_monotonic, :parsing_start_time_offset, :parsing_duration) do
+        def reset
+          members.each do |member|
+            self[member] = nil
+          end
+        end
+      end
+
       def pre_context
         # NOTE: This is used to store timings from lexing, parsing, validation, before we have a context to store
         # values in. Uses thread-safe Concurrent::ThreadLocalVar to store a set of values per thread.
-        @pre_context ||= Concurrent::ThreadLocalVar.new(OpenStruct.new)
+        @pre_context ||= Concurrent::ThreadLocalVar.new(PreContext.new)
+        @pre_context.value
       end
 
-      def setup_tracing_before_lexing
-        pre_context.value.query_start_time = GraphQL::Metrics.current_time
-        pre_context.value.query_start_time_monotonic = GraphQL::Metrics.current_time_monotonic
+      def setup_tracing
+        pre_context.reset
+        pre_context.query_start_time = GraphQL::Metrics.current_time
+        pre_context.query_start_time_monotonic = GraphQL::Metrics.current_time_monotonic
 
         yield
       end
@@ -68,22 +76,22 @@ module GraphQL
       def capture_parsing_time
         timed_result = GraphQL::Metrics.time { yield }
 
-        pre_context.value.parsing_start_time_offset = timed_result.start_time
-        pre_context.value.parsing_duration = timed_result.duration
+        pre_context.parsing_start_time_offset = timed_result.start_time
+        pre_context.parsing_duration = timed_result.duration
 
         timed_result.result
       end
 
       def capture_validation_time(context)
-        timed_result = GraphQL::Metrics.time(pre_context.value.query_start_time_monotonic) { yield }
+        timed_result = GraphQL::Metrics.time(pre_context.query_start_time_monotonic) { yield }
 
         ns = context.namespace(CONTEXT_NAMESPACE)
         previous_validation_duration = ns[GraphQL::Metrics::VALIDATION_DURATION] || 0
 
-        ns[QUERY_START_TIME] = pre_context.value.query_start_time
-        ns[QUERY_START_TIME_MONOTONIC] = pre_context.value.query_start_time_monotonic
-        ns[PARSING_START_TIME_OFFSET] = pre_context.value.parsing_start_time_offset
-        ns[PARSING_DURATION] = pre_context.value.parsing_duration
+        ns[QUERY_START_TIME] = pre_context.query_start_time
+        ns[QUERY_START_TIME_MONOTONIC] = pre_context.query_start_time_monotonic
+        ns[PARSING_START_TIME_OFFSET] = pre_context.parsing_start_time_offset
+        ns[PARSING_DURATION] = pre_context.parsing_duration
         ns[VALIDATION_START_TIME_OFFSET] = timed_result.time_since_offset
         ns[VALIDATION_DURATION] = timed_result.duration + previous_validation_duration
 


### PR DESCRIPTION
This PR adds support for executing already parsed GraphQL queries which fixes #27. 

The `pre_context` thread local in `GraphQL::Metrics::Tracer` persists across executions which makes fixing this issue a little thorny. In particular if the `lex` and `parse` callbacks aren't invoked, then the `query_start_time`, `query_start_time_monotonic`, `parsing_start_time_offset`, and `parsing_duration` state from the previous execution leak into the current execution. Thus the `validate` callbacks can't tell if this state is from the current execution or a previous execution. I handled that by reseting state in the `execute_multiplex` callback which seems to fire at the desired time when invoking `GraphQL::Schema.execute` or `GraphQL::Schema.multiplex`:

Invoking `GraphQL::Schema.execute` results in the following trace callbacks:

1. `execute_multiplex`
1. `lex` (skipped if passed a parsed query)
1. `parse` (skipped if passed a parsed query)
1. `validate`
1. `analyze_multiplex`
1. `analyze_query`
1. `execute_query`
1. `...`

Invoking `GraphQL::Schema.multiplex` with two queries results in the following trace callbacks:

1. `execute_multiplex`
1. `lex` (skipped if passed a parsed query)
1. `parse` (skipped if passed a parsed query)
1. `validate`
1. `lex` (skipped if passed a parsed query)
1. `parse` (skipped if passed a parsed query)
1. `validate` (skipped if passed a parsed query)
1. `analyze_multiplex`
1. `analyze_query`
1. `analyze_query`
1. `execute_query`
1. `execute_query`
1. `...`

The tests were originally instantiating a `GraphQL::Query` and then invoking `GraphQL::Query#result` which resulted in a slightly different order of callbacks (namely `execute_multiplex` came after `parse`) but I don't think that needs to be supported since it's not the documented way of executing queries with graphql-ruby.