### PR TITLE
Handle queries that have already been parsed, split validate and analyze_query tracer events

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-metrics (4.0.1)
+    graphql-metrics (4.0.2)
       concurrent-ruby (~> 1.1.0)
       graphql (>= 1.10.8)
 

--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -28,6 +28,8 @@ module GraphQL
     PARSING_DURATION = :parsing_duration
     VALIDATION_START_TIME_OFFSET = :validation_start_time_offset
     VALIDATION_DURATION = :validation_duration
+    ANALYSIS_START_TIME_OFFSET = :analysis_start_time_offset
+    ANALYSIS_DURATION = :analysis_duration
     INLINE_FIELD_TIMINGS = :inline_field_timings
     LAZY_FIELD_TIMINGS = :lazy_field_timings
 

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -45,6 +45,8 @@ module GraphQL
             parsing_duration: ns[GraphQL::Metrics::PARSING_DURATION],
             validation_start_time_offset: ns[GraphQL::Metrics::VALIDATION_START_TIME_OFFSET],
             validation_duration: ns[GraphQL::Metrics::VALIDATION_DURATION],
+            analysis_start_time_offset: ns[GraphQL::Metrics::ANALYSIS_START_TIME_OFFSET],
+            analysis_duration: ns[GraphQL::Metrics::ANALYSIS_DURATION],
           }
 
           analyzer.extract_fields

--- a/lib/graphql/metrics/tracer.rb
+++ b/lib/graphql/metrics/tracer.rb
@@ -6,7 +6,8 @@ module GraphQL
       # NOTE: These constants come from the graphql ruby gem.
       GRAPHQL_GEM_LEXING_KEY = 'lex'
       GRAPHQL_GEM_PARSING_KEY = 'parse'
-      GRAPHQL_GEM_VALIDATION_KEYS = ['validate', 'analyze_query']
+      GRAPHQL_GEM_VALIDATION_KEY = 'validate'
+      GRAPHQL_GEM_ANALYZE_KEY = 'analyze_query'
       GRAPHQL_GEM_TRACING_FIELD_KEYS = [
         GRAPHQL_GEM_TRACING_FIELD_KEY = 'execute_field',
         GRAPHQL_GEM_TRACING_LAZY_FIELD_KEY = 'execute_field_lazy'
@@ -26,11 +27,12 @@ module GraphQL
           return setup_tracing_before_lexing(&block)
         when GRAPHQL_GEM_PARSING_KEY
           return capture_parsing_time(&block)
-        when *GRAPHQL_GEM_VALIDATION_KEYS
+        when GRAPHQL_GEM_VALIDATION_KEY
           context = possible_context
-
-          return yield unless context.query.valid?
           return capture_validation_time(context, &block)
+        when GRAPHQL_GEM_ANALYZE_KEY
+          context = possible_context
+          return capture_analysis_time(context, &block)
         when *GRAPHQL_GEM_TRACING_FIELD_KEYS
           return yield if data[:query].context[SKIP_FIELD_AND_ARGUMENT_METRICS]
           return yield unless GraphQL::Metrics.timings_capture_enabled?(data[:query].context)
@@ -85,14 +87,24 @@ module GraphQL
         timed_result = GraphQL::Metrics.time(pre_context.value.query_start_time_monotonic) { yield }
 
         ns = context.namespace(CONTEXT_NAMESPACE)
-        previous_validation_duration = ns[GraphQL::Metrics::VALIDATION_DURATION] || 0
 
         ns[QUERY_START_TIME] = pre_context.value.query_start_time
         ns[QUERY_START_TIME_MONOTONIC] = pre_context.value.query_start_time_monotonic
         ns[PARSING_START_TIME_OFFSET] = pre_context.value.parsing_start_time_offset
         ns[PARSING_DURATION] = pre_context.value.parsing_duration
         ns[VALIDATION_START_TIME_OFFSET] = timed_result.time_since_offset
-        ns[VALIDATION_DURATION] = timed_result.duration + previous_validation_duration
+        ns[VALIDATION_DURATION] = timed_result.duration
+
+        timed_result.result
+      end
+
+      def capture_analysis_time(context)
+        ns = context.namespace(CONTEXT_NAMESPACE)
+
+        timed_result = GraphQL::Metrics.time(ns[QUERY_START_TIME_MONOTONIC]) { yield }
+
+        ns[ANALYSIS_START_TIME_OFFSET] = timed_result.time_since_offset
+        ns[ANALYSIS_DURATION] = timed_result.duration
 
         timed_result.result
       end

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -38,14 +38,12 @@ module GraphQL
       end
 
       class SimpleAnalyzer < GraphQL::Metrics::Analyzer
-        ANALYZER_NAMESPACE = :simple_analyzer_namespace
-
         attr_reader :types_used, :context
 
         def initialize(query_or_multiplex)
           super
 
-          @context = query_or_multiplex.context.namespace(ANALYZER_NAMESPACE)
+          @context = query_or_multiplex.context
           @context[:simple_extractor_results] = {
             queries: [],
             fields: [],
@@ -68,7 +66,7 @@ module GraphQL
         private
 
         def store_metrics(context_key, metrics)
-          context[:simple_extractor_results][context_key] << metrics
+          @context[:simple_extractor_results][context_key] << metrics
         end
       end
 
@@ -90,25 +88,87 @@ module GraphQL
         end
       end
 
-      test 'extracts metrics from queries, as well as their fields and arguments' do
+      test 'extracts metrics from queries, as well as their fields and arguments (when using Query#result)' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
           operation_name: 'PostDetails',
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         actual_queries = results[:queries]
         actual_fields = results[:fields]
         actual_arguments = results[:arguments]
 
         assert_equal_with_diff_on_failure(kitchen_sink_expected_queries, actual_queries)
+        assert_equal_with_diff_on_failure(kitchen_sink_expected_fields, actual_fields)
+        assert_equal_with_diff_on_failure(kitchen_sink_expected_arguments, actual_arguments)
+      end
+
+      test 'extracts metrics from queries, as well as their fields and arguments (when using Query.execute)' do
+        context = {}
+        result = SchemaWithFullMetrics.execute(
+          kitchen_sink_query_document,
+          variables: { 'postId': '1', 'titleUpcase': true },
+          operation_name: 'PostDetails',
+          context: context
+        )
+
+        refute result['errors'].present?
+        assert result['data'].present?
+
+        results = context[:simple_extractor_results]
+
+        actual_queries = results[:queries]
+        actual_fields = results[:fields]
+        actual_arguments = results[:arguments]
+
+        assert_equal_with_diff_on_failure(kitchen_sink_expected_queries, actual_queries)
+        assert_equal_with_diff_on_failure(kitchen_sink_expected_fields, actual_fields)
+        assert_equal_with_diff_on_failure(kitchen_sink_expected_arguments, actual_arguments)
+      end
+
+      test 'extracts metrics from queries that have already been parsed, omitting parsing timings' do
+        context = {}
+        query = GraphQL::Query.new(
+          SchemaWithFullMetrics,
+          document: GraphQL.parse(kitchen_sink_query_document),
+          variables: { 'postId': '1', 'titleUpcase': true },
+          operation_name: 'PostDetails',
+          context: context
+        )
+        result = query.result.to_h
+
+        refute result['errors'].present?
+        assert result['data'].present?
+
+        results = context[:simple_extractor_results]
+
+        actual_queries = results[:queries]
+        actual_fields = results[:fields]
+        actual_arguments = results[:arguments]
+
+        expected_queries = [
+          {
+            :operation_type=>"query",
+            :operation_name=>"PostDetails",
+            :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
+            :query_duration=>SomeNumber.new(at_least: 2),
+            :parsing_start_time_offset=>SomeNumber.new(at_least: 0),
+            :parsing_duration=>SomeNumber.new(at_least: 0),
+            :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          }
+        ]
+        assert_equal_with_diff_on_failure(expected_queries, actual_queries)
         assert_equal_with_diff_on_failure(kitchen_sink_expected_fields, actual_fields)
         assert_equal_with_diff_on_failure(kitchen_sink_expected_arguments, actual_arguments)
       end
@@ -131,8 +191,7 @@ module GraphQL
         metrics_results = multiplex_results.map do |multiplex_result|
           metrics_result = multiplex_result
             .query
-            .context
-            .namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+            .context[:simple_extractor_results]
 
           {
             queries: metrics_result[:queries],
@@ -220,17 +279,18 @@ module GraphQL
       end
 
       test "safely skips logging arguments metrics for fields, when the argument value look up fails (possibly because it failed input coercion)" do
+        context = { raise_in_prepare: true }
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
           operation_name: 'PostDetails',
-          context: { raise_in_prepare: true }
+          context: context
         )
 
         result = query.result.to_h
 
-        metrics_results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        metrics_results = context[:simple_extractor_results]
 
         actual_queries = metrics_results[:queries]
         actual_fields = metrics_results[:fields]
@@ -242,18 +302,20 @@ module GraphQL
       end
 
       test "safely returns static metrics if runtime metrics gathering is interrupted" do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
-          operation_name: 'PostDetails'
+          operation_name: 'PostDetails',
+          context: context
         )
 
         GraphQL::Metrics::Instrumentation.any_instance.expects(:runtime_metrics_interrupted?).returns(true)
 
         result = query.result.to_h
 
-        metrics_results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        metrics_results = context[:simple_extractor_results]
 
         actual_queries = metrics_results[:queries]
         actual_fields = metrics_results[:fields]
@@ -276,21 +338,23 @@ module GraphQL
       end
 
       test 'skips logging for fields and arguments if `skip_field_and_argument_metrics: true` in context' do
+        context = {
+          GraphQL::Metrics::SKIP_FIELD_AND_ARGUMENT_METRICS => true,
+        }
+
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
           operation_name: 'PostDetails',
-          context: {
-            GraphQL::Metrics::SKIP_FIELD_AND_ARGUMENT_METRICS => true,
-          }
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         actual_queries = results[:queries]
         actual_fields = results[:fields]
@@ -332,29 +396,32 @@ module GraphQL
       end
 
       test 'skips analysis, instrumentation and tracing if `skip_graphql_metrics_analysis` is set to true in the context' do
+        context = { skip_graphql_metrics_analysis: true }
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
           operation_name: 'PostDetails',
-          context: { skip_graphql_metrics_analysis: true }
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         expected = {:queries=>[], :fields=>[], :arguments=>[]}
         assert_equal(expected, results)
       end
 
       test 'extracts metrics manually via analyze call, with args supplied inline' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           mutation_document_inline_args,
           operation_name: 'PostCreate',
+          context: context
         )
 
         result = query.result.to_h
@@ -362,13 +429,14 @@ module GraphQL
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
         actual_arguments = results[:arguments]
 
         assert_equal_with_diff_on_failure(shared_expected_arguments_metrics, actual_arguments)
       end
 
       test 'extracts metrics manually via analyze call with args supplied by variables' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           mutation_document,
@@ -385,6 +453,7 @@ module GraphQL
             }
           },
           operation_name: 'PostCreate',
+          context: context
         )
 
         result = query.result.to_h
@@ -392,23 +461,25 @@ module GraphQL
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
         actual_arguments = results[:arguments]
 
         assert_equal_with_diff_on_failure(shared_expected_arguments_metrics, actual_arguments)
       end
 
       test 'fields requested that are not resolved (e.g. id for a post that itself was never resolved) produce no inline field timings' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           '{ post(id: "missing_post") { id } }',
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         actual_fields = results[:fields]
         id_field_metric = actual_fields.find { |f| f[:path] == %w(post id) }
@@ -477,6 +548,7 @@ module GraphQL
       end
 
       test 'extracts metrics from mutations, input objects' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithFullMetrics,
           mutation_document,
@@ -491,13 +563,14 @@ module GraphQL
             }
           },
           operation_name: 'PostCreate',
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         actual_queries = results[:queries]
         actual_fields = results[:fields]
@@ -628,18 +701,20 @@ module GraphQL
       end
 
       test 'works as simple analyzer, gathering static metrics with no runtime data when the analyzer is not used as instrumentation and or a tracer' do
+        context = {}
         query = GraphQL::Query.new(
           SchemaWithoutTimingMetrics,
           kitchen_sink_query_document,
           variables: { 'postId': '1', 'titleUpcase': true },
           operation_name: 'PostDetails',
+          context: context
         )
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        results = context[:simple_extractor_results]
 
         actual_queries = results[:queries]
         actual_fields = results[:fields]
@@ -837,12 +912,13 @@ module GraphQL
           }
         GRAPHQL
 
-        query = GraphQL::Query.new(SchemaWithFullMetrics, query_document)
+        context = {}
+        query = GraphQL::Query.new(SchemaWithFullMetrics, query_document, context: context)
         result = query.result.to_h
         refute result['errors'].present?
         assert result['data'].present?
 
-        metrics_results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        metrics_results = context[:simple_extractor_results]
         actual_arguments = metrics_results[:arguments]
 
         expected_arguments = [
@@ -880,13 +956,14 @@ module GraphQL
           }
         GRAPHQL
 
-        query = GraphQL::Query.new(SchemaWithFullMetrics, query_document)
+        context = {}
+        query = GraphQL::Query.new(SchemaWithFullMetrics, query_document, context: context)
         result = query.result.to_h
 
         refute result['errors'].present?
         assert result['data'].present?
 
-        metrics_results = query.context.namespace(SimpleAnalyzer::ANALYZER_NAMESPACE)[:simple_extractor_results]
+        metrics_results = context[:simple_extractor_results]
         actual_arguments = metrics_results[:arguments]
 
         expected_arguments = [

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -175,10 +175,10 @@ module GraphQL
         assert_equal_with_diff_on_failure(kitchen_sink_expected_arguments, actual_arguments)
       end
 
-      test 'extracts metrics in all of the same ways, when a multiplex is executed' do
+      test 'extracts metrics in all of the same ways, when a multiplex is executed - regardless if queries are pre-parsed or not' do
         queries = [
           {
-            query: 'query OtherQuery { post(id: "42") { id title } }',
+            document: GraphQL.parse('query OtherQuery { post(id: "42") { id title } }'),
             operation_name: 'OtherQuery',
           },
           {
@@ -209,9 +209,9 @@ module GraphQL
           :operation_type => "query",
           :operation_name => "OtherQuery",
           :query_start_time => SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
-          :query_duration => SomeNumber.new(at_least: 2),
-          :parsing_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          :parsing_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          :query_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          :parsing_start_time_offset => SomeNumber.new(at_least: 0),
+          :parsing_duration => SomeNumber.new(at_least: 0),
           :validation_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :validation_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -166,6 +166,8 @@ module GraphQL
             :parsing_duration=>SomeNumber.new(at_least: 0),
             :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           }
         ]
         assert_equal_with_diff_on_failure(expected_queries, actual_queries)
@@ -212,6 +214,8 @@ module GraphQL
           :parsing_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :validation_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :validation_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
         }]
 
         expected_other_query_fields = [{
@@ -586,6 +590,8 @@ module GraphQL
             :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           }
         ]
 
@@ -1004,6 +1010,8 @@ module GraphQL
             :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           }
         ]
       end


### PR DESCRIPTION
Closes https://github.com/Shopify/graphql-metrics/issues/27
Closes https://github.com/Shopify/graphql-metrics/issues/31

These two issues touch enough of the same Tracer logic that I thought I'd fix both at once.

* Splits handling and timing capture for the `parse` and `validate` tracer events, to fix #31
  * We now serve up `analysis_start_time_offset` and `analysis_duration` metrics separately
* Resetting just parsing metrics stored on the `PreContext` struct (great idea Joel!), and doing so after taking these values out and storing them in the individual query contexts (under the gem's namespace)
* We'll now always have a `pre_context.query_start_time` present, now that we're considering the always-invoked `execute_multiplex` tracer event as our starting point.
* Took a cue from https://github.com/Shopify/graphql-metrics/pull/30 to simply the `context` in the integration tests to be a simple hash, rather than using a namespace and needing to extract a context object.

Thank you @jturkel, I've incorporated some of the progress you made in https://github.com/Shopify/graphql-metrics/pull/30 here.