### PR TITLE
Fix query start time, start time offset bugs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-metrics (4.0.5)
+    graphql-metrics (4.0.6)
       concurrent-ruby (~> 1.1.0)
       graphql (>= 1.10.8)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ parsing and validation runtime metrics will not be added to the `metrics` hash.
     #   validation_duration: 0.01704599999357015,
     #   analysis_start_time_offset: 0.0010339999571442604,
     #   analysis_duration: 0.0008190000080503523,
+    #   multiplex_start_time: 0.0008190000080503523,
     # }
     #
     # You can use these metrics to track high-level query performance, along with any other details you wish to

--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -22,6 +22,8 @@ module GraphQL
     ANALYZER_INSTANCE_KEY = :analyzer_instance
 
     # Context keys to store timings for query phases of execution, field resolver timings.
+    MULTIPLEX_START_TIME = :multiplex_start_time
+    MULTIPLEX_START_TIME_MONOTONIC = :multiplex_start_time_monotonic
     QUERY_START_TIME = :query_start_time
     QUERY_START_TIME_MONOTONIC = :query_start_time_monotonic
     PARSING_START_TIME_OFFSET = :parsing_start_time_offset

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -47,6 +47,7 @@ module GraphQL
             validation_duration: ns[GraphQL::Metrics::VALIDATION_DURATION],
             analysis_start_time_offset: ns[GraphQL::Metrics::ANALYSIS_START_TIME_OFFSET],
             analysis_duration: ns[GraphQL::Metrics::ANALYSIS_DURATION],
+            multiplex_start_time: ns[GraphQL::Metrics::MULTIPLEX_START_TIME],
           }
 
           analyzer.extract_fields

--- a/lib/graphql/metrics/version.rb
+++ b/lib/graphql/metrics/version.rb
@@ -2,6 +2,6 @@
 
 module GraphQL
   module Metrics
-    VERSION = "4.0.5"
+    VERSION = "4.0.6"
   end
 end


### PR DESCRIPTION
* Captures the `multiplex_start_time` via the universally-invoked `execute_multiplex` tracer event
* Field timings are now relative to their actual parent query (e.g. if in a multiplex) rather than at the beginning of lexing.
* Emitting `multiplex_start_time` as the start time for all metrics events