### PR TITLE
Stop using analysis modules explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,9 +181,6 @@ class Schema < GraphQL::Schema
   query QueryRoot
   mutation MutationRoot
 
-  use GraphQL::Execution::Interpreter # Required.
-  use GraphQL::Analysis::AST # Required.
-
   query_analyzer SimpleAnalyzer
 
   instrument :query, GraphQL::Metrics::Instrumentation.new # Both of these are required if either is used.
@@ -202,9 +199,6 @@ analyzer without `GraphQL::Metrics::Instrumentation` and `tracer GraphQL::Metric
 class Schema < GraphQL::Schema
   query QueryRoot
   mutation MutationRoot
-
-  use GraphQL::Execution::Interpreter # Required.
-  use GraphQL::Analysis::AST # Required.
 
   query_analyzer SimpleAnalyzer
 end


### PR DESCRIPTION
Declare to use analysis modules (such as `GraphQL::Execution::Interpreter` and `GraphQL::Analysis::AST`) is deprecated since graphql-ruby v1.12.0, so I just updated documentation.

see changelog: https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#1120-20-january-2021