### PR TITLE
DNM - debug tracing, instrumentation timings

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -46,6 +46,8 @@ module GraphQL
 
         extract_arguments(argument_values, visitor.field_definition) if argument_values
 
+        puts "  * Analyzer.on_leave_field - #{node.name}"
+
         static_metrics = {
           field_name: node.name,
           return_type_name: visitor.type_definition.graphql_name,

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -9,6 +9,8 @@ module GraphQL
           query.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS] = true
         end
 
+        puts '* Instrumentation.before_query'
+
         # Even if queries are present and valid, applications may set this context value in order to opt out of
         # having Analyzer and Tracer gather runtime metrics.
         # If we're skipping runtime metrics, then both Instrumentation before_ and after_query can and should be
@@ -37,6 +39,8 @@ module GraphQL
           analyzer.extract_query
         else
           query_duration = GraphQL::Metrics.current_time_monotonic - ns[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC]
+
+          puts '* Instrumentation.after_query - query_duration extracted for current query'
 
           runtime_query_metrics = {
             query_start_time: ns[GraphQL::Metrics::QUERY_START_TIME],

--- a/lib/graphql/metrics/tracer.rb
+++ b/lib/graphql/metrics/tracer.rb
@@ -17,6 +17,8 @@ module GraphQL
       ]
 
       def trace(key, data, &block)
+        puts "* Tracer.trace(#{key})"
+
         # NOTE: Context doesn't exist yet during lexing, parsing.
         possible_context = data[:query]&.context
 
@@ -87,6 +89,8 @@ module GraphQL
       end
 
       def capture_multiplex_start_time
+        puts "  * Capturing pre_context.multiplex_start_time_* in pre_context"
+
         pre_context.multiplex_start_time = GraphQL::Metrics.current_time
         pre_context.multiplex_start_time_monotonic = GraphQL::Metrics.current_time_monotonic
 
@@ -98,6 +102,8 @@ module GraphQL
         # `pre_context.multiplex_start_time_monotonic` isn't set.
         lexing_offset_time = pre_context.multiplex_start_time_monotonic || GraphQL::Metrics.current_time_monotonic
         timed_result = GraphQL::Metrics.time(lexing_offset_time) { yield }
+
+        puts "  * Capturing pre_context.lexing_* in pre_context"
 
         pre_context.lexing_start_time_offset = timed_result.start_time
         pre_context.lexing_duration = timed_result.duration
@@ -113,6 +119,8 @@ module GraphQL
 
         pre_context.parsing_start_time_offset = timed_result.start_time
         pre_context.parsing_duration = timed_result.duration
+
+        puts "  * Capturing pre_context.parsing_* in pre_context"
 
         timed_result.result
       end
@@ -143,6 +151,9 @@ module GraphQL
         ns[VALIDATION_START_TIME_OFFSET] = timed_result.time_since_offset
         ns[VALIDATION_DURATION] = timed_result.duration
 
+        puts "  * Capturing last pre_context.parsing_*, lexing_* times in this query's context"
+        puts "  * Capturing validation time in this query's context"
+
         timed_result.result
       end
 
@@ -154,6 +165,8 @@ module GraphQL
         ns[ANALYSIS_START_TIME_OFFSET] = timed_result.time_since_offset
         ns[ANALYSIS_DURATION] = timed_result.duration
 
+        puts "  * Capturing analysis time in this query's context"
+
         timed_result.result
       end
 
@@ -162,7 +175,11 @@ module GraphQL
         ns[QUERY_START_TIME] = GraphQL::Metrics.current_time
         ns[QUERY_START_TIME_MONOTONIC] = GraphQL::Metrics.current_time_monotonic
 
+        puts "  * Capturing execute time in this query's context"
+
         yield
+
+        puts " AFTER capture_query_start_time"
       end
 
       def trace_field(context_key, data)
@@ -176,6 +193,8 @@ module GraphQL
         ns[context_key][path_excluding_numeric_indicies] << {
           start_time_offset: timed_result.time_since_offset, duration: timed_result.duration
         }
+
+        puts "  * Capturing field execution time in this query's context"
 
         timed_result.result
       end

--- a/test/test_schema.rb
+++ b/test/test_schema.rb
@@ -37,6 +37,12 @@ class Post < GraphQL::Schema::Object
 
   field :id, ID, null: false
 
+  def id
+    puts '  * in Post.id resolver'
+
+    object[:id]
+  end
+
   field :title, String, null: false do
     argument :upcase, Boolean, required: false, prepare: ->(value, ctx) do
       if ctx[:raise_in_prepare]
@@ -47,8 +53,20 @@ class Post < GraphQL::Schema::Object
     end
   end
 
+  def title
+    puts '  * in Post.title resolver'
+
+    object[:title]
+  end
+
   field :body, String, null: false do
     argument :truncate, Boolean, required: false, default_value: false
+  end
+
+  def body(truncate:)
+    puts '  * in Post.body resolver'
+
+    object[:body]
   end
 
   field :deprecated_body, String, null: false, method: :body, deprecation_reason: 'Use `body` instead.'
@@ -59,6 +77,8 @@ class Post < GraphQL::Schema::Object
   end
 
   def comments(args)
+    puts '  * in Post.comments resolver'
+
     CommentLoader.for(Comment).load_many(args[:ids]).then { |comments| comments }
   end
 end


### PR DESCRIPTION
Expanding on issues raised in https://github.com/Shopify/graphql-metrics/pull/44 and https://github.com/Shopify/graphql-metrics/issues/45.

Run `bundle exec rake` to see the output from #45.

Note: I added a helper method `off_test` to take the place of `skip`ping tests, which add a bunch of `S` characters to the terminal output. I'm just avoiding those for clarity when copy-pasting output.