### PR TITLE
Clarify tracer execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,11 +219,11 @@ order in which methods defined on `GraphQL::Metrics::Instrumentation`, `GraphQL:
 Although you ideally will not need to care about these details if you are simply using this gem to gather metrics in
 your application as intended, here's a breakdown of the order of execution of the methods involved:
 
- When used as instrumentation, an analyzer and tracing, the order of execution is:
+ When used as instrumentation, an analyzer and tracing, the order of execution is usually:
 
+* Tracer.capture_multiplex_start_time
 * Tracer.capture_lexing_time
 * Tracer.capture_parsing_time
-* Tracer.capture_multiplex_start_time
 * Instrumentation.before_query (context setup)
 * Tracer.capture_validation_time
 * Tracer.capture_analysis_time

--- a/lib/graphql/metrics/tracer.rb
+++ b/lib/graphql/metrics/tracer.rb
@@ -4,10 +4,12 @@ module GraphQL
   module Metrics
     class Tracer
       # NOTE: These constants come from the graphql ruby gem and are in "chronological" order based on the phases
-      # of execution of the graphql-ruby gem. Most of them can be run multiple times when multiplexing multiple queries.
+      # of execution of the graphql-ruby gem, though old versions of the gem aren't always consistent about this (see
+      # https://github.com/rmosolgo/graphql-ruby/issues/3393). Most of them can be run multiple times when
+      # multiplexing multiple queries.
+      GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY = 'execute_multiplex' # wraps everything below this line; only run once
       GRAPHQL_GEM_LEXING_KEY = 'lex' # may not trigger if the query is passed in pre-parsed
       GRAPHQL_GEM_PARSING_KEY = 'parse' # may not trigger if the query is passed in pre-parsed
-      GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY = 'execute_multiplex' # wraps everything below this line; only run once
       GRAPHQL_GEM_VALIDATION_KEY = 'validate'
       GRAPHQL_GEM_ANALYZE_MULTIPLEX_KEY = 'analyze_multiplex' # wraps all `analyze_query`s; only run once
       GRAPHQL_GEM_ANALYZE_QUERY_KEY = 'analyze_query'
@@ -24,12 +26,12 @@ module GraphQL
         return yield if skip_tracing
 
         case key
+        when GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY
+          return capture_multiplex_start_time(&block)
         when GRAPHQL_GEM_LEXING_KEY
           return capture_lexing_time(&block)
         when GRAPHQL_GEM_PARSING_KEY
           return capture_parsing_time(&block)
-        when GRAPHQL_GEM_EXECUTE_MULTIPLEX_KEY
-          return capture_multiplex_start_time(&block)
         when GRAPHQL_GEM_VALIDATION_KEY
           return capture_validation_time(context, &block)
         when GRAPHQL_GEM_ANALYZE_MULTIPLEX_KEY


### PR DESCRIPTION
Since https://github.com/rmosolgo/graphql-ruby/issues/3393 it should at
least be consistent.