### PR TITLE
Fix grandparent name for inline fragments

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -171,8 +171,11 @@ module GraphQL
           DIRECTIVE_TYPE
         end
 
-        grand_parent_name = if parent.is_a?(GraphQL::Language::Nodes::OperationDefinition)
+        grand_parent_name = case parent
+        when GraphQL::Language::Nodes::OperationDefinition
           parent.operation_type
+        when GraphQL::Language::Nodes::InlineFragment
+          parent.type.name
         else
           parent.name
         end


### PR DESCRIPTION
`grandparent_name` call was failing during argument extraction.
Specifically, when query contained inline fragments and children fields contained arguments.

Example:
arguments extracted
```
[...    
       {    
            argument_name: "upcase",
            argument_type_name: "Boolean",
            parent_name: "title",
            grandparent_type_name: "Post",
            grandparent_node_name: "Post",   # name of the fragment
            parent_input_object_type: nil,
            default_used: false,
            value_is_null: false,
            value: SomeArgumentValue.new,
        }
...]
```

```graphql
        query PostDetails($postId: ID!, $titleUpcase: Boolean = false, $val: Int!) @customDirective(val: $val) {
            post(id: $postId) {
              __typename # Ignored
              ... on Post {
                id @skip(if: true)
                title(upcase: $titleUpcase) // <---- this was problematic case, grandparent will be Post type name
              }
            }
          }
```