### PR TITLE
Reset lex in pre-context

### DIFF
--- a/lib/graphql/metrics/tracer.rb
+++ b/lib/graphql/metrics/tracer.rb
@@ -75,6 +75,8 @@ module GraphQL
           self[:multiplex_start_time_monotonic] = nil
           self[:parsing_start_time_offset] = nil
           self[:parsing_duration] = nil
+          self[:lexing_start_time_offset] = nil
+          self[:lexing_duration] = nil
         end
       end
 


### PR DESCRIPTION
I noticed `lexing_duration` was leaking across queries when the second query on the same thread is initialized with a document. Instead of `0.0` it was reporting the lexing duration of the previous query.