### PR TITLE
Addresses an error when inline fragments with directive were missing parent type

### DIFF
--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -175,7 +175,7 @@ module GraphQL
         when GraphQL::Language::Nodes::OperationDefinition
           parent.operation_type
         when GraphQL::Language::Nodes::InlineFragment
-          parent.type.name
+          parent&.type&.name
         else
           parent.name
         end


### PR DESCRIPTION
By the spec, type for inline fragments is optional, grand_parent_name https://github.com/Shopify/graphql-metrics/issues/70#issuecomment-1470767082

Closes #70