### PR TITLE
Trace: capture path before yielding

### DIFF
--- a/lib/graphql/metrics/trace.rb
+++ b/lib/graphql/metrics/trace.rb
@@ -181,13 +181,14 @@ module GraphQL
         ns = query.context.namespace(CONTEXT_NAMESPACE)
         offset_time = ns[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC]
         start_time = GraphQL::Metrics.current_time_monotonic
+        path = query.context[:current_path]
 
         result = yield
 
         duration = GraphQL::Metrics.current_time_monotonic - start_time
         time_since_offset = start_time - offset_time if offset_time
 
-        path_excluding_numeric_indicies = query.context[:current_path].select { |p| p.is_a?(String) }
+        path_excluding_numeric_indicies = path.select { |p| p.is_a?(String) }
         ns[context_key][path_excluding_numeric_indicies] ||= []
         ns[context_key][path_excluding_numeric_indicies] << {
           start_time_offset: time_since_offset, duration: duration


### PR DESCRIPTION
graphql-ruby can reset the `current_path` in context if an operation is executed within the resolver of another opeeration.

https://github.com/rmosolgo/graphql-ruby/pull/4445 fixes this but capturing the path before yielding is another solution that works in the meantime.