### PR TITLE
Centralize Ruby Version to `.ruby-version`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@
 /spec/reports/
 /tmp/
 *.gem
-Gemfile.lock
 /vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,2 @@
 inherit_from:
   - http://shopify.github.io/ruby-style-guide/rubocop.yml
-
-AllCops:
-  TargetRubyVersion: 2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,69 @@
+PATH
+  remote: .
+  specs:
+    graphql-metrics (5.0.8)
+      concurrent-ruby (>= 1.1.0)
+      graphql (>= 1.12.10)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.1.7)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    base64 (0.2.0)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.3)
+    diffy (3.4.2)
+    fakeredis (0.9.2)
+      redis (~> 4.8)
+    graphql (2.3.0)
+      base64
+    graphql-batch (0.6.0)
+      graphql (>= 1.12.18, < 3)
+      promise.rb (~> 0.7.2)
+    hashdiff (1.1.0)
+    i18n (1.14.4)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.22.3)
+    minitest-focus (1.4.0)
+      minitest (>= 4, < 6)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
+    promise.rb (0.7.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    rake (13.1.0)
+    redis (4.8.1)
+    ruby2_keywords (0.0.5)
+    thread_safe (0.3.6)
+    tzinfo (1.2.11)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  arm64-darwin-23
+
+DEPENDENCIES
+  activesupport (~> 5.1.5)
+  diffy
+  fakeredis
+  graphql-batch
+  graphql-metrics!
+  hashdiff
+  minitest (~> 5.0)
+  minitest-focus
+  mocha
+  pry
+  pry-byebug
+  rake
+
+BUNDLED WITH
+   2.4.1

--- a/graphql_metrics.gemspec
+++ b/graphql_metrics.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Shopify/graphql-metrics'
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.7"
+
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
The `.ruby-version` file is the ecosystem standard for defining a Ruby version.  This PR adds the `.ruby-version` file, ensures a `required_ruby_version` is set, and removes all other references to Ruby in this repository, aligning it with the standard.
> [!IMPORTANT]
> Please verify the following before merging:

Verify that the changes in the PR meets the following requirements or adjust manually to make it compliant:
  - [x] `.ruby-version` file is present with the correct Ruby version defined
  - [x] A `required_ruby_version` in your gemspec is set
  - [x] There is no Ruby version present in the  `dev.yml` Ruby task (before: `- ruby: x.x.x`, after: `- ruby`)
  - [x] There is no Ruby version/requirement referenced in the `Gemfile` (no lines with `ruby  <some-version>`)
  - [x] A `Gemfile.lock` is built with the defined Ruby version (https://bundler.io/guides/faq.html#using-gemfiles-inside-gems)
  - [x] The version of Rubocop installed is 1.61.0 or greater
  - [x] There is no `TargetRubyVersion` defined  in `rubocop.yml`
  - [x] There is no Ruby argument  present in  `ruby/setup-ruby` Github Actions that do **not**  run on a Ruby matrix (no lines with `ruby-version: “x.x”`)

Please merge this PR if it looks good, this PR will be merged if there isn't any activity after 4 weeks.