### PR TITLE
Remove Apollo tracing spec support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ etc.
 What you do with these captured metrics is up to you!
 
 **NOTE**: If any non-`graphql-ruby` gem-related exceptions occur in your application during query document
-parsing and validation, **runtime metrics** for queries (like `query_duration`, `parsing_start_time_offset` etc.) as well as field
+parsing and validation, **runtime metrics** for queries (like `query_duration`, etc.) as well as field
 resolver timings (like `resolver_timings`, `lazy_resolver_timings`) **may not be present** in the extracted `metrics` hash,
 even if you opt to collect them by using `GraphQL::Metrics::Analyzer` and `GraphQL::Metrics::Tracer`.
 
@@ -75,13 +75,9 @@ even if you opt to collect them by using `GraphQL::Metrics::Analyzer` and `Graph
     #   operation_name: "PostDetails",
     #   query_start_time: 1573833076.027327,
     #   query_duration: 2.0207119999686256,
-    #   lexing_start_time_offset: 0.0010339999571442604,
     #   lexing_duration: 0.0008190000080503523,
-    #   parsing_start_time_offset: 0.0010339999571442604,
     #   parsing_duration: 0.0008190000080503523,
-    #   validation_start_time_offset: 0.0030819999519735575,
     #   validation_duration: 0.01704599999357015,
-    #   analysis_start_time_offset: 0.0010339999571442604,
     #   analysis_duration: 0.0008190000080503523,
     #   multiplex_start_time: 0.0008190000080503523,
     # }
@@ -129,12 +125,10 @@ even if you opt to collect them by using `GraphQL::Metrics::Analyzer` and `Graph
     #   deprecated: false,
     #   path: ["post", "id"],
     #   resolver_timings: [
-    #     start_time_offset: 0.011901999998372048,
-    #     duration: 5.999987479299307e-06
+    #     5.999987479299307e-06,
     #   ],
     #   lazy_resolver_timings: [
-    #     start_time_offset: 0.031901999998372048,
-    #     duration: 5.999987479299307e-06
+    #     5.999987479299307e-06,
     #   ],
     # }
     def field_extracted(metrics)

--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -27,13 +27,9 @@ module GraphQL
     MULTIPLEX_START_TIME_MONOTONIC = :multiplex_start_time_monotonic
     QUERY_START_TIME = :query_start_time
     QUERY_START_TIME_MONOTONIC = :query_start_time_monotonic
-    LEXING_START_TIME_OFFSET = :lexing_start_time_offset
     LEXING_DURATION = :lexing_duration
-    PARSING_START_TIME_OFFSET = :parsing_start_time_offset
     PARSING_DURATION = :parsing_duration
-    VALIDATION_START_TIME_OFFSET = :validation_start_time_offset
     VALIDATION_DURATION = :validation_duration
-    ANALYSIS_START_TIME_OFFSET = :analysis_start_time_offset
     ANALYSIS_DURATION = :analysis_duration
     INLINE_FIELD_TIMINGS = :inline_field_timings
     LAZY_FIELD_TIMINGS = :lazy_field_timings
@@ -51,40 +47,11 @@ module GraphQL
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
-    def self.time(offset_time = nil)
+    def self.time
       start_time = current_time_monotonic
       result = yield
       duration = current_time_monotonic - start_time
-      time_since_offset = start_time - offset_time if offset_time
-      TimedResult.new(start_time, duration, time_since_offset, result)
-    end
-
-    class TimedResult
-      # NOTE: `time_since_offset` is used to produce start times timed phases of execution (validation, field
-      # resolution). These start times are relative to the executed operation's start time, which is captured at the
-      # outset of document parsing.
-      #
-      # The times produced are intentionally similar to:
-      # https://github.com/apollographql/apollo-tracing#response-format
-      #
-      # Taking a field resolver start offset example:
-      #
-      # <   start offset   >
-      # |------------------|----------|--------->
-      # OS (t=0)           FS (t=1)   FE (t=2)
-      #
-      # OS = Operation start time
-      # FS = Field resolver start time
-      # FE = Field resolver end time
-      #
-      attr_reader :result, :start_time, :duration, :time_since_offset
-
-      def initialize(start_time, duration, time_since_offset, result)
-        @start_time = start_time
-        @duration = duration
-        @time_since_offset = time_since_offset
-        @result = result
-      end
+      [result, duration]
     end
   end
 end

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -41,13 +41,9 @@ module GraphQL
           runtime_query_metrics = {
             query_start_time: ns[GraphQL::Metrics::QUERY_START_TIME],
             query_duration: query_duration,
-            parsing_start_time_offset: ns[GraphQL::Metrics::PARSING_START_TIME_OFFSET],
             parsing_duration: ns[GraphQL::Metrics::PARSING_DURATION],
-            validation_start_time_offset: ns[GraphQL::Metrics::VALIDATION_START_TIME_OFFSET],
             validation_duration: ns[GraphQL::Metrics::VALIDATION_DURATION],
-            lexing_start_time_offset: ns[GraphQL::Metrics::LEXING_START_TIME_OFFSET],
             lexing_duration: ns[GraphQL::Metrics::LEXING_DURATION],
-            analysis_start_time_offset: ns[GraphQL::Metrics::ANALYSIS_START_TIME_OFFSET],
             analysis_duration: ns[GraphQL::Metrics::ANALYSIS_DURATION],
             multiplex_start_time: ns[GraphQL::Metrics::MULTIPLEX_START_TIME],
           }

--- a/test/unit/graphql/metrics/integration_test.rb
+++ b/test/unit/graphql/metrics/integration_test.rb
@@ -548,13 +548,9 @@ module GraphQL
             :operation_name=>"PostDetails",
             :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             :query_duration=>SomeNumber.new(at_least: 2),
-            :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :lexing_duration=>SomeNumber.new(at_least: 0),
-            :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :parsing_duration=>SomeNumber.new(at_least: 0),
-            :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
           }
@@ -590,8 +586,6 @@ module GraphQL
 
         second_query_result = second_query_context[:simple_extractor_results][:queries][0]
 
-        assert(first_query_result[:lexing_start_time_offset] < second_query_result[:lexing_start_time_offset])
-        assert(first_query_result[:parsing_start_time_offset] < second_query_result[:parsing_start_time_offset])
         assert_equal(0.0, second_query_result[:lexing_duration])
         assert_equal(0.0, second_query_result[:parsing_duration])
       end
@@ -655,13 +649,9 @@ module GraphQL
           :operation_name => "OtherQuery",
           :query_start_time => SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
           :query_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          :lexing_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :lexing_duration => SomeNumber.new(at_least: 0),
-          :parsing_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :parsing_duration => SomeNumber.new(at_least: 0),
-          :validation_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :validation_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
           :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
         }]
@@ -672,10 +662,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "title",
@@ -683,10 +670,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "title"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "post",
@@ -694,10 +678,7 @@ module GraphQL
           :parent_type_name => "QueryRoot",
           :deprecated => false,
           :path => ["post"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }]
 
@@ -1042,13 +1023,9 @@ module GraphQL
             :operation_name=>"PostCreate",
             :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             :query_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :lexing_duration=>SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-            :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
           }
@@ -1064,10 +1041,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["postCreate", "post", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "post",
@@ -1075,10 +1049,7 @@ module GraphQL
           :parent_type_name => "PostCreatePayload",
           :deprecated => false,
           :path => ["postCreate", "post"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "postCreate",
@@ -1086,10 +1057,7 @@ module GraphQL
           :parent_type_name => "MutationRoot",
           :deprecated => false,
           :path => ["postCreate"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }]
 
@@ -1481,13 +1449,9 @@ module GraphQL
             :operation_name=>"PostDetails",
             :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             :query_duration=>SomeNumber.new(at_least: 2),
-            :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :lexing_duration=>SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-            :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
           }
@@ -1501,10 +1465,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "title",
@@ -1512,10 +1473,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "title"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "body",
@@ -1523,10 +1481,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "ignoredAlias"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "deprecatedBody",
@@ -1534,10 +1489,7 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => true,
           :path => ["post", "deprecatedBody"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "id",
@@ -1545,13 +1497,10 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "comments", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "body",
@@ -1559,13 +1508,10 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "comments", "body"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "id",
@@ -1573,19 +1519,12 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "comments", "comments", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "body",
@@ -1593,19 +1532,12 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "comments", "comments", "body"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "comments",
@@ -1613,47 +1545,36 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "comments", "comments"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
-          :lazy_resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: 1)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }]
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
+          :lazy_resolver_timings => [
+            SomeNumber.new(at_least: 1),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
         }, {
           :field_name => "comments",
           :return_type_name => "Comment",
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "comments"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
-          :lazy_resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: 1)
-          }]
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
+          :lazy_resolver_timings => [
+            SomeNumber.new(at_least: 1),
+          ],
         }, {
           :field_name => "id",
           :return_type_name => "ID",
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "otherComments", "id"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "body",
@@ -1661,13 +1582,10 @@ module GraphQL
           :parent_type_name => "Comment",
           :deprecated => false,
           :path => ["post", "otherComments", "body"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }, {
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }, {
           :field_name => "comments",
@@ -1675,24 +1593,21 @@ module GraphQL
           :parent_type_name => "Post",
           :deprecated => false,
           :path => ["post", "otherComments"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
-          :lazy_resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }]
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
+          :lazy_resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
         }, {
           :field_name => "post",
           :return_type_name => "Post",
           :parent_type_name => "QueryRoot",
           :deprecated => false,
           :path => ["post"],
-          :resolver_timings => [{
-            :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-          }],
+          :resolver_timings => [
+            SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+          ],
           :lazy_resolver_timings => [],
         }]
       end

--- a/test/unit/graphql/metrics/trace_integration_test.rb
+++ b/test/unit/graphql/metrics/trace_integration_test.rb
@@ -508,13 +508,9 @@ if GraphQL::Schema.respond_to?(:trace_with)
               :operation_name=>"PostDetails",
               :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
               :query_duration=>SomeNumber.new(at_least: 2),
-              :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :lexing_duration=>SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-              :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :parsing_duration=>SomeNumber.new(at_least: 0),
-              :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             }
@@ -583,13 +579,9 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :operation_name => "OtherQuery",
             :query_start_time => SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             :query_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :lexing_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :lexing_duration => SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-            :parsing_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :parsing_duration => SomeNumber.new(at_least: 0),
-            :validation_start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :validation_duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
             :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
           }]
@@ -600,10 +592,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "title",
@@ -611,10 +600,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "title"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "post",
@@ -622,10 +608,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "QueryRoot",
             :deprecated => false,
             :path => ["post"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }]
 
@@ -970,13 +953,9 @@ if GraphQL::Schema.respond_to?(:trace_with)
               :operation_name=>"PostCreate",
               :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
               :query_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :lexing_duration=>SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-              :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             }
@@ -992,10 +971,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["postCreate", "post", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "post",
@@ -1003,10 +979,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "PostCreatePayload",
             :deprecated => false,
             :path => ["postCreate", "post"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "postCreate",
@@ -1014,10 +987,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "MutationRoot",
             :deprecated => false,
             :path => ["postCreate"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }]
 
@@ -1409,13 +1379,9 @@ if GraphQL::Schema.respond_to?(:trace_with)
               :operation_name=>"PostDetails",
               :query_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
               :query_duration=>SomeNumber.new(at_least: 2),
-              :lexing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :lexing_duration=>SomeNumber.new(at_least: lexing_duration_for_graphql_version),
-              :parsing_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :parsing_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :validation_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :validation_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :analysis_start_time_offset=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :analysis_duration=>SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
               :multiplex_start_time=>SomeNumber.new(at_least: REASONABLY_RECENT_UNIX_TIME),
             }
@@ -1429,10 +1395,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "title",
@@ -1440,10 +1403,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "title"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "body",
@@ -1451,10 +1411,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "ignoredAlias"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "deprecatedBody",
@@ -1462,10 +1419,7 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => true,
             :path => ["post", "deprecatedBody"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "id",
@@ -1473,13 +1427,10 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "comments", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "body",
@@ -1487,13 +1438,10 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "comments", "body"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "id",
@@ -1501,19 +1449,12 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "comments", "comments", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "body",
@@ -1521,19 +1462,12 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "comments", "comments", "body"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "comments",
@@ -1541,47 +1475,36 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "comments", "comments"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
-            :lazy_resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: 1)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }]
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
+            :lazy_resolver_timings => [
+              SomeNumber.new(at_least: 1),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
           }, {
             :field_name => "comments",
             :return_type_name => "Comment",
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "comments"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
-            :lazy_resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: 1)
-            }]
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
+            :lazy_resolver_timings => [
+              SomeNumber.new(at_least: 1),
+            ],
           }, {
             :field_name => "id",
             :return_type_name => "ID",
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "otherComments", "id"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "body",
@@ -1589,13 +1512,10 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Comment",
             :deprecated => false,
             :path => ["post", "otherComments", "body"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }, {
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }, {
             :field_name => "comments",
@@ -1603,24 +1523,21 @@ if GraphQL::Schema.respond_to?(:trace_with)
             :parent_type_name => "Post",
             :deprecated => false,
             :path => ["post", "otherComments"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
-            :lazy_resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }]
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
+            :lazy_resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
           }, {
             :field_name => "post",
             :return_type_name => "Post",
             :parent_type_name => "QueryRoot",
             :deprecated => false,
             :path => ["post"],
-            :resolver_timings => [{
-              :start_time_offset => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
-              :duration => SomeNumber.new(at_least: SMALL_NONZERO_NUMBER)
-            }],
+            :resolver_timings => [
+              SomeNumber.new(at_least: SMALL_NONZERO_NUMBER),
+            ],
             :lazy_resolver_timings => [],
           }]
         end


### PR DESCRIPTION
Apollo's tracing [spec](https://github.com/apollographql/apollo-tracing) has long been deprecated. This removes support for `offset` timestamps which were only needed for Apollo tracing.

Dropping these offsets simplifies our code and lets us store an array of resolver timing duration timestamps instead of hashes as well.

This is a **breaking** change. However, at least internally at Shopify, we never consumed these offsets.

Note: I'm extracting a few cleanups/changes from https://github.com/Shopify/graphql-metrics/pull/81 to ship them separately.