### PR TITLE
Refactor static metric mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,10 +243,9 @@ class Schema < GraphQL::Schema
   query QueryRoot
   mutation MutationRoot
 
-  query_analyzer SimpleAnalyzer
-
   instrument :query, GraphQL::Metrics::Instrumentation.new # Both of these are required if either is used.
   trace_with GraphQL::Metrics::Trace                       # <-- Note!
+  query_analyzer SimpleAnalyzer
 
   use GraphQL::Batch # Optional, but highly recommended. See https://github.com/Shopify/graphql-batch/.
 end
@@ -254,20 +253,33 @@ end
 
 ### Optionally, only gather static metrics
 
-If you don't care to capture runtime metrics like query and resolver timings, you can use your analyzer a standalone
-analyzer without `GraphQL::Metrics::Instrumentation` and `trace_with GraphQL::Metrics::Trace`, like so:
+If you don't care to capture field timings metrics, they can be disabled with the `capture_field_timings` option:
 
 ```ruby
 class Schema < GraphQL::Schema
   query QueryRoot
   mutation MutationRoot
 
+  instrument :query, GraphQL::Metrics::Instrumentation.new(capture_field_timings: false)
   query_analyzer SimpleAnalyzer
+  trace_with GraphQL::Metrics::Trace
 end
 ```
 
 Your analyzer will still be called with `query_extracted`, `field_extracted`, but with timings metrics omitted.
-`argument_extracted` will work exactly the same, whether instrumentation and tracing are used or not.
+`argument_extracted` will work exactly the same.
+
+And if you want to disable tracing metrics entirely, the tracer can be omitted as well:
+
+```ruby
+class Schema < GraphQL::Schema
+  query QueryRoot
+  mutation MutationRoot
+
+  instrument :query, GraphQL::Metrics::Instrumentation.new(capture_field_timings: false)
+  query_analyzer SimpleAnalyzer
+end
+```
 
 ## Order of execution
 

--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -33,11 +33,6 @@ module GraphQL
     INLINE_FIELD_TIMINGS = :inline_field_timings
     LAZY_FIELD_TIMINGS = :lazy_field_timings
 
-    def self.timings_capture_enabled?(context)
-      return false unless context
-      !!context.namespace(CONTEXT_NAMESPACE)[TIMINGS_CAPTURE_ENABLED]
-    end
-
     def self.current_time
       Process.clock_gettime(Process::CLOCK_REALTIME)
     end

--- a/lib/graphql/metrics/analyzer.rb
+++ b/lib/graphql/metrics/analyzer.rb
@@ -51,20 +51,13 @@ module GraphQL
           path: visitor.response_path,
         }
 
-        if GraphQL::Metrics.timings_capture_enabled?(query.context)
-          @static_field_metrics << static_metrics
-        else
-          field_extracted(static_metrics)
-        end
+        @static_field_metrics << static_metrics
       end
 
       def extract_fields(with_runtime_metrics: true)
-        return if query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
-
         ns = query.context.namespace(CONTEXT_NAMESPACE)
 
         @static_field_metrics.each do |static_metrics|
-
           if with_runtime_metrics
             resolver_timings = ns[GraphQL::Metrics::INLINE_FIELD_TIMINGS][static_metrics[:path]]
             lazy_resolver_timings = ns[GraphQL::Metrics::LAZY_FIELD_TIMINGS][static_metrics[:path]]
@@ -89,14 +82,6 @@ module GraphQL
       end
 
       def result
-        return if GraphQL::Metrics.timings_capture_enabled?(query.context)
-        return if query.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS]
-
-        # NOTE: If we're running as a static analyzer (i.e. not with instrumentation and tracing), we still need to
-        # flush static query metrics somewhere other than `after_query`.
-        ns = query.context.namespace(CONTEXT_NAMESPACE)
-        analyzer = ns[GraphQL::Metrics::ANALYZER_INSTANCE_KEY]
-        analyzer.extract_query
       end
 
       private

--- a/lib/graphql/metrics/trace.rb
+++ b/lib/graphql/metrics/trace.rb
@@ -59,13 +59,13 @@ module GraphQL
 
       def execute_field(field:, query:, ast_node:, arguments:, object:)
         return super if skip_tracing?(query) || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
-        return super unless GraphQL::Metrics.timings_capture_enabled?(query.context)
+        return super unless capture_field_timings?(query.context)
         trace_field(GraphQL::Metrics::INLINE_FIELD_TIMINGS, query) { super }
       end
 
       def execute_field_lazy(field:, query:, ast_node:, arguments:, object:)
         return super if skip_tracing?(query) || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
-        return super unless GraphQL::Metrics.timings_capture_enabled?(query.context)
+        return super unless capture_field_timings?(query.context)
         trace_field(GraphQL::Metrics::LAZY_FIELD_TIMINGS, query) { super }
       end
 
@@ -77,6 +77,16 @@ module GraphQL
         end
 
         @skip_tracing
+      end
+
+      def capture_field_timings?(context)
+        !!context.namespace(CONTEXT_NAMESPACE)[TIMINGS_CAPTURE_ENABLED]
+
+        if !defined?(@capture_field_timings)
+          @capture_field_timings = !!context.namespace(CONTEXT_NAMESPACE)[TIMINGS_CAPTURE_ENABLED]
+        end
+
+        @capture_field_timings
       end
 
       PreContext = Struct.new(


### PR DESCRIPTION
Previously the analyzer could be run in a "standalone" mode (without instrumentation or tracer) to collect static metrics only (excluding timings). This refactors that solution by introducing a `capture_field_timings` option on the instrumentation instead.

This simplifies the analyzer by eliminating the conditional modes; now it always runs in the same way. It will also make the next step of migrating off the deprecated instrumentation plugins easier.

Note: this will only be merged after https://github.com/Shopify/graphql-metrics/pull/85