### PR TITLE
Migrate Instrumentation to tracing

### DIFF
--- a/lib/graphql/metrics.rb
+++ b/lib/graphql/metrics.rb
@@ -47,5 +47,26 @@ module GraphQL
       duration = current_time_monotonic - start_time
       [result, duration]
     end
+
+    def self.use(
+      schema_defn,
+      analyzer_class:,
+      tracer: GraphQL::Metrics::Trace,
+      capture_timings: nil,
+      capture_field_timings: nil,
+      trace_mode: :default
+    )
+      if capture_field_timings && !capture_timings
+        raise ArgumentError, "Cannot capture field timings without capturing query timings"
+      end
+
+      capture_timings = true if capture_timings.nil?
+      capture_field_timings = true if capture_field_timings.nil?
+      capture_field_timings = false if !capture_timings
+
+      schema_defn.trace_with(GraphQL::Metrics::Instrumentation, capture_field_timings: capture_field_timings)
+      schema_defn.trace_with(tracer, mode: trace_mode) if capture_timings
+      schema_defn.query_analyzer(analyzer_class)
+    end
   end
 end

--- a/lib/graphql/metrics/instrumentation.rb
+++ b/lib/graphql/metrics/instrumentation.rb
@@ -2,32 +2,39 @@
 
 module GraphQL
   module Metrics
-    class Instrumentation
-      def initialize(capture_field_timings: true)
+    module Instrumentation
+      def initialize(capture_field_timings: true, **_options)
         @capture_field_timings = capture_field_timings
+
+        super
       end
 
-      def before_query(query)
-        unless query_present_and_valid?(query)
-          # Setting this prevents Analyzer and Tracer from trying to gather runtime metrics for invalid queries.
-          query.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS] = true
+      def execute_multiplex(multiplex:)
+        return super if multiplex.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS]
+
+        result = nil
+
+        multiplex.queries.each do |query|
+          ns = query.context.namespace(CONTEXT_NAMESPACE)
+          ns[GraphQL::Metrics::TIMINGS_CAPTURE_ENABLED] = @capture_field_timings
+          ns[GraphQL::Metrics::INLINE_FIELD_TIMINGS] = Hash.new { |h, k| h[k] = [] }
+          ns[GraphQL::Metrics::LAZY_FIELD_TIMINGS] = Hash.new { |h, k| h[k] = [] }
         end
 
-        # Even if queries are present and valid, applications may set this context value in order to opt out of
-        # having Analyzer and Tracer gather runtime metrics.
-        # If we're skipping runtime metrics, then both Instrumentation before_ and after_query can and should be
-        # short-circuited as well.
-        return if query.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS]
+        begin
+          result = super
+        ensure
+          multiplex.queries.each do |query|
+            handle_query(query)
+          end
+        end
 
-        ns = query.context.namespace(CONTEXT_NAMESPACE)
-        ns[GraphQL::Metrics::TIMINGS_CAPTURE_ENABLED] = @capture_field_timings
-        ns[GraphQL::Metrics::INLINE_FIELD_TIMINGS] = {}
-        ns[GraphQL::Metrics::LAZY_FIELD_TIMINGS] = {}
+        result
       end
 
-      def after_query(query)
-        return if query.context[GraphQL::Metrics::SKIP_GRAPHQL_METRICS_ANALYSIS]
+      private
 
+      def handle_query(query)
         ns = query.context.namespace(CONTEXT_NAMESPACE)
         analyzer = ns[GraphQL::Metrics::ANALYZER_INSTANCE_KEY]
 
@@ -49,7 +56,6 @@ module GraphQL
             validation_duration: ns[GraphQL::Metrics::VALIDATION_DURATION],
             lexing_duration: ns[GraphQL::Metrics::LEXING_DURATION],
             analysis_duration: ns[GraphQL::Metrics::ANALYSIS_DURATION],
-            multiplex_start_time: ns[GraphQL::Metrics::MULTIPLEX_START_TIME],
           }
 
           analyzer.extract_fields(with_runtime_metrics: @capture_field_timings)
@@ -58,12 +64,6 @@ module GraphQL
       end
 
       private
-
-      def query_present_and_valid?(query)
-        # Check for selected_operation as well for graphql 1.9 compatibility
-        # which did not reject "empty" documents in its parser.
-        query.valid? && !query.selected_operation.nil?
-      end
 
       def runtime_metrics_interrupted?(context_namespace)
         # NOTE: The start time stored at `ns[GraphQL::Metrics::QUERY_START_TIME_MONOTONIC]` is captured during query

--- a/lib/graphql/metrics/trace.rb
+++ b/lib/graphql/metrics/trace.rb
@@ -8,18 +8,14 @@ module GraphQL
 
         query_or_multiplex = @query || @multiplex
         @skip_tracing = query_or_multiplex.context&.fetch(SKIP_GRAPHQL_METRICS_ANALYSIS, false) if query_or_multiplex
+        @parsing_duration = 0.0
+        @lexing_duration = 0.0
       end
 
       # NOTE: These methods come from the graphql ruby gem and are in "chronological" order based on the phases
       # of execution of the graphql-ruby gem, though old versions of the gem aren't always consistent about this (see
       # https://github.com/rmosolgo/graphql-ruby/issues/3393). Most of them can be run multiple times when
       # multiplexing multiple queries.
-
-      # wraps everything below this line; only run once
-      def execute_multiplex(multiplex:)
-        return super if skip_tracing?(multiplex)
-        capture_multiplex_start_time { super }
-      end
 
       # may not trigger if the query is passed in pre-parsed
       def lex(query_string:)
@@ -34,54 +30,35 @@ module GraphQL
       end
 
       def validate(query:, validate:)
-        return super if skip_tracing?(query)
+        return super if @skip_tracing
         capture_validation_time(query.context) { super }
       end
 
-      # wraps all `analyze_query`s; only run once
-      def analyze_multiplex(multiplex:)
-        return super if skip_tracing?(multiplex)
-        # Ensures that we reset potentially long-lived PreContext objects between multiplexs. We reset at this point
-        # since all parsing and validation will be done by this point, and a GraphQL::Query::Context will exist.
-        pre_context.reset
-        super
-      end
-
       def analyze_query(query:)
-        return super if skip_tracing?(query)
+        return super if @skip_tracing
         capture_analysis_time(query.context) { super }
       end
 
       def execute_query(query:)
-        return super if skip_tracing?(query)
+        return super if @skip_tracing
         capture_query_start_time(query.context) { super }
       end
 
       def execute_field(field:, query:, ast_node:, arguments:, object:)
-        return super if skip_tracing?(query) || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
+        return super if @skip_tracing || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
         return super unless capture_field_timings?(query.context)
         trace_field(GraphQL::Metrics::INLINE_FIELD_TIMINGS, query) { super }
       end
 
       def execute_field_lazy(field:, query:, ast_node:, arguments:, object:)
-        return super if skip_tracing?(query) || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
+        return super if @skip_tracing || query.context[SKIP_FIELD_AND_ARGUMENT_METRICS]
         return super unless capture_field_timings?(query.context)
         trace_field(GraphQL::Metrics::LAZY_FIELD_TIMINGS, query) { super }
       end
 
       private
 
-      def skip_tracing?(query_or_multiplex)
-        if !defined?(@skip_tracing)
-          @skip_tracing = query_or_multiplex.context&.fetch(SKIP_GRAPHQL_METRICS_ANALYSIS, false)
-        end
-
-        @skip_tracing
-      end
-
       def capture_field_timings?(context)
-        !!context.namespace(CONTEXT_NAMESPACE)[TIMINGS_CAPTURE_ENABLED]
-
         if !defined?(@capture_field_timings)
           @capture_field_timings = !!context.namespace(CONTEXT_NAMESPACE)[TIMINGS_CAPTURE_ENABLED]
         end
@@ -89,69 +66,25 @@ module GraphQL
         @capture_field_timings
       end
 
-      PreContext = Struct.new(
-        :multiplex_start_time,
-        :multiplex_start_time_monotonic,
-        :parsing_duration,
-        :lexing_duration
-      ) do
-        def reset
-          self[:multiplex_start_time] = nil
-          self[:multiplex_start_time_monotonic] = nil
-          self[:parsing_duration] = nil
-          self[:lexing_duration] = nil
-        end
-      end
-
-      def pre_context
-        # NOTE: This is used to store timings from lexing, parsing, validation, before we have a context to store
-        # values in. Uses thread-safe Concurrent::ThreadLocalVar to store a set of values per thread.
-        @pre_context ||= Concurrent::ThreadLocalVar.new(PreContext.new)
-        @pre_context.value
-      end
-
-      def capture_multiplex_start_time
-        pre_context.multiplex_start_time = GraphQL::Metrics.current_time
-        pre_context.multiplex_start_time_monotonic = GraphQL::Metrics.current_time_monotonic
-
-        yield
-      end
-
       def capture_lexing_time
         result, duration = GraphQL::Metrics.time { yield }
-
-        pre_context.lexing_duration = duration
-
+        @lexing_duration = duration
         result
       end
 
       def capture_parsing_time
         result, duration = GraphQL::Metrics.time { yield }
-
-        pre_context.parsing_duration = duration
-
+        @parsing_duration = duration
         result
       end
 
-      # Also consolidates parsing timings (if any) from the `pre_context`
+      # Also consolidates parsing timings (if any)
       def capture_validation_time(context)
-        # Queries may already be lexed and parsed before execution (whether a single query or multiplex).
-        # If we don't have those values, use some sane defaults.
-        if [nil, 0].include?(pre_context.lexing_duration)
-          pre_context.lexing_duration = 0.0
-        end
-        if pre_context.parsing_duration.nil?
-          pre_context.parsing_duration = 0.0
-        end
-
         result, duration = GraphQL::Metrics.time { yield }
 
         ns = context.namespace(CONTEXT_NAMESPACE)
-
-        ns[MULTIPLEX_START_TIME] = pre_context.multiplex_start_time
-        ns[MULTIPLEX_START_TIME_MONOTONIC] = pre_context.multiplex_start_time_monotonic
-        ns[LEXING_DURATION] = pre_context.lexing_duration
-        ns[PARSING_DURATION] = pre_context.parsing_duration
+        ns[LEXING_DURATION] = @lexing_duration
+        ns[PARSING_DURATION] = @parsing_duration
         ns[VALIDATION_DURATION] = duration
 
         result


### PR DESCRIPTION
This is a mostly 1:1 migration of the existing `Instrumentation` plugin to a trace module now that instrumentation is deprecated.

Migration steps:

1. Update schema with `use GraphQL::Metrics` and any options instead of explicitly adding analyzers and tracers
2. Remove any usage of `multiplex_start_time` since it's been removed